### PR TITLE
Add NATS.connect module method to connect

### DIFF
--- a/spec/auth_spec.rb
+++ b/spec/auth_spec.rb
@@ -53,6 +53,13 @@ describe 'Client - Authorization' do
       nats.connect(:servers => [TEST_TOKEN_AUTH_SERVER], :reconnect => false)
       nats.flush
     end.to_not raise_error
+
+
+    expect do
+      nc = NATS.connect(TEST_TOKEN_AUTH_SERVER, reconnect: false)
+      nc.flush
+    end.to_not raise_error
+
     nats.close
   end
 

--- a/spec/client_cluster_reconnect_spec.rb
+++ b/spec/client_cluster_reconnect_spec.rb
@@ -100,8 +100,7 @@ describe 'Client - Cluster reconnect' do
       mon = Monitor.new
       reconnected = mon.new_cond
 
-      nats = NATS::IO::Client.new
-      nats.connect(:servers => [@s1.uri, @s2.uri], :dont_randomize_servers => true)
+      nats = NATS.connect(:servers => [@s1.uri, @s2.uri], :dont_randomize_servers => true)
 
       disconnects = 0
       nats.on_disconnect do
@@ -385,7 +384,7 @@ describe 'Client - Cluster reconnect' do
         end
 
         # Connect to first server only and trigger reconnect
-        nats.connect("nats://secret:password@127.0.0.1:4242", :dont_randomize_servers => true, :reconnect => true)
+        nats.connect("nats://secret:password@127.0.0.1:4242", :dont_randomize_servers => true, :reconnect => true, :reconnect_time_wait => 0.5)
         expect(nats.connected_server.to_s).to eql(@s1.uri.to_s)
         @s1.kill_server
         sleep 0.1

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -27,20 +27,41 @@ describe 'Client - Specification' do
     sleep 1
   end
 
-  it 'should connect to locally available server by default' do
-    nc = NATS::IO::Client.new
+  it 'should connect' do
     expect do
-      nc.connect(:servers => [@s.uri])
+      nc = NATS::IO::Client.new
+      nc.connect(servers: [@s.uri])
+      nc.close
     end.to_not raise_error
-    nc.close
-  end
 
-  it 'should connect to using a single uri' do
-    nc = NATS::IO::Client.new
+    # Using module method
     expect do
-      nc.connect("nats://127.0.0.1:4522")
+      nc = NATS.connect(servers: [@s.uri])
+      nc.close
     end.to_not raise_error
-    nc.close
+
+    # Single URI
+    expect do
+      nc = NATS.connect("nats://127.0.0.1:4522")
+      nc.close
+    end.to_not raise_error
+
+    expect do
+      nc = NATS.connect(@s.uri)
+      nc.close
+    end.to_not raise_error
+
+    expect do
+      nc = NATS::IO::Client.new
+      nc.connect("nats://127.0.0.1:4522")
+      nc.close
+    end.to_not raise_error
+
+    expect do
+      nc = NATS::IO::Client.new
+      nc.connect("127.0.0.1:4522")
+      nc.close
+    end.to_not raise_error
   end
 
   it 'should received a message when subscribed to a topic' do


### PR DESCRIPTION
Added `NATS.connect` module method that works similar to `nats.connect` from Go package.

```ruby
# Returns a new NATS::IO::Client.new instance
nc = NATS.connect("nats://demo.nats.io:4222")
nc = NATS.connect(servers: ["nats://demo.nats.io:4222"])
```

Also added logic to prevent multiple uses of `connect` when using the same client instance across different threads.

```ruby
nc = NATS::IO::Client.new
nc.connect("nats://demo.nats.io:4222")
nc.connect("nats://demo.nats.io:4222") # Will not reattempt to connect if already called once.
```

Signed-off-by: Waldemar Quevedo <wally@synadia.com>