### PR TITLE
Raise ArgumentError if prohibited characters used in stream name

### DIFF
--- a/lib/nats/io/js.rb
+++ b/lib/nats/io/js.rb
@@ -284,6 +284,7 @@ module NATS
                  end
         stream = config[:name]
         raise ArgumentError.new(":name is required to create streams") unless stream
+        raise ArgumentError.new("Spaces, tabs, period (.), greater than (>) or asterisk (*) are prohibited in stream names") if stream =~ /(\s|\.|\>|\*)/
         req_subject = "#{@prefix}.STREAM.CREATE.#{stream}"
         result = api_request(req_subject, config.to_json, params)
         JetStream::API::StreamCreateResponse.new(result)

--- a/spec/js_spec.rb
+++ b/spec/js_spec.rb
@@ -951,6 +951,11 @@ describe 'JetStream' do
       expect do 
         nc.jsm.add_stream(foo: "foo.*")
       end.to raise_error(ArgumentError)
+
+      # Raise when stream names contain prohibited characters
+      expect do 
+        nc.jsm.add_stream(name: "foo.bar*baz")
+      end.to raise_error(ArgumentError)
       nc.close
     end
 


### PR DESCRIPTION
Hi, I ran into an issue where I had an invalid stream name, but the API simply times out when calling `add_stream` with no indication that the stream name was invalid. Since the nats cli will tell you `nats: error: could not create Stream: "foo.bar" is not a valid stream name`, I assume that it makes sense for the Ruby client do the same. I copied the language in the exception directly from https://docs.nats.io/running-a-nats-service/nats_admin/jetstream_admin/naming. Thanks!