### PR TITLE
Optionally disable detecting missing servers that have been announced

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,16 @@ Then in the client specify the path to the seed using the `nkeys_seed` option:
 NATS.connect("tls://connect.ngs.global", nkeys_seed: "path/to/seed.txt")
 ```
 
+### Cluster Server Discovery
+
+By default, when you connect to a NATS server that's in a cluster,
+the client will take information about servers it doesn't know about yet.
+This can be disabled at connection time:
+
+```ruby
+NATS.connect(servers: ['nats://127.0.0.1:4444'], detect_missing_announced_server: false)
+```
+
 ## License
 
 Unless otherwise noted, the NATS source files are distributed under

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ the client will take information about servers it doesn't know about yet.
 This can be disabled at connection time:
 
 ```ruby
-NATS.connect(servers: ['nats://127.0.0.1:4444'], detect_missing_announced_server: false)
+NATS.connect(servers: ['nats://127.0.0.1:4444'], discover_missing_cluster_servers: false)
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ the client will take information about servers it doesn't know about yet.
 This can be disabled at connection time:
 
 ```ruby
-NATS.connect(servers: ['nats://127.0.0.1:4444'], discover_missing_cluster_servers: false)
+NATS.connect(servers: ['nats://127.0.0.1:4444'], ignore_discovered_urls: true)
 ```
 
 ## License

--- a/lib/nats/io/client.rb
+++ b/lib/nats/io/client.rb
@@ -227,7 +227,7 @@ module NATS
       opts[:pedantic] = false if opts[:pedantic].nil?
       opts[:reconnect] = true if opts[:reconnect].nil?
       opts[:old_style_request] = false if opts[:old_style_request].nil?
-      opts[:detect_missing_announced_server] = true if opts[:detect_missing_announced_server].nil?
+      opts[:discover_missing_cluster_servers] = true if opts[:discover_missing_cluster_servers].nil?
       opts[:reconnect_time_wait] = NATS::IO::RECONNECT_TIME_WAIT if opts[:reconnect_time_wait].nil?
       opts[:max_reconnect_attempts] = NATS::IO::MAX_RECONNECT_ATTEMPTS if opts[:max_reconnect_attempts].nil?
       opts[:ping_interval] = NATS::IO::DEFAULT_PING_INTERVAL if opts[:ping_interval].nil?
@@ -238,7 +238,7 @@ module NATS
       opts[:pedantic] = ENV['NATS_PEDANTIC'].downcase == 'true' unless ENV['NATS_PEDANTIC'].nil?
       opts[:reconnect] = ENV['NATS_RECONNECT'].downcase == 'true' unless ENV['NATS_RECONNECT'].nil?
       opts[:reconnect_time_wait] = ENV['NATS_RECONNECT_TIME_WAIT'].to_i unless ENV['NATS_RECONNECT_TIME_WAIT'].nil?
-      opts[:detect_missing_announced_server] = ENV['NATS_DETECT_MISSING_ANNOUNCED_SERVER'].downcase == 'true' unless ENV['NATS_DETECT_MISSING_ANNOUNCED_SERVER'].nil?
+      opts[:discover_missing_cluster_servers] = ENV['NATS_discover_missing_cluster_servers'].downcase == 'true' unless ENV['NATS_discover_missing_cluster_servers'].nil?
       opts[:max_reconnect_attempts] = ENV['NATS_MAX_RECONNECT_ATTEMPTS'].to_i unless ENV['NATS_MAX_RECONNECT_ATTEMPTS'].nil?
       opts[:ping_interval] = ENV['NATS_PING_INTERVAL'].to_i unless ENV['NATS_PING_INTERVAL'].nil?
       opts[:max_outstanding_pings] = ENV['NATS_MAX_OUTSTANDING_PINGS'].to_i unless ENV['NATS_MAX_OUTSTANDING_PINGS'].nil?
@@ -809,7 +809,7 @@ module NATS
 
         # Detect any announced server that we might not be aware of...
         connect_urls = @server_info[:connect_urls]
-        if @options[:detect_missing_announced_server] && connect_urls
+        if @options[:discover_missing_cluster_servers] && connect_urls
           srvs = []
           connect_urls.each do |url|
             scheme = client_using_secure_connection? ? "tls" : "nats"

--- a/lib/nats/io/client.rb
+++ b/lib/nats/io/client.rb
@@ -238,7 +238,7 @@ module NATS
       opts[:pedantic] = ENV['NATS_PEDANTIC'].downcase == 'true' unless ENV['NATS_PEDANTIC'].nil?
       opts[:reconnect] = ENV['NATS_RECONNECT'].downcase == 'true' unless ENV['NATS_RECONNECT'].nil?
       opts[:reconnect_time_wait] = ENV['NATS_RECONNECT_TIME_WAIT'].to_i unless ENV['NATS_RECONNECT_TIME_WAIT'].nil?
-      opts[:discover_missing_cluster_servers] = ENV['NATS_discover_missing_cluster_servers'].downcase == 'true' unless ENV['NATS_discover_missing_cluster_servers'].nil?
+      opts[:discover_missing_cluster_servers] = ENV['NATS_DISCOVER_MISSING_CLUSTER_SERVERS'].downcase == 'true' unless ENV['NATS_DISCOVER_MISSING_CLUSTER_SERVERS'].nil?
       opts[:max_reconnect_attempts] = ENV['NATS_MAX_RECONNECT_ATTEMPTS'].to_i unless ENV['NATS_MAX_RECONNECT_ATTEMPTS'].nil?
       opts[:ping_interval] = ENV['NATS_PING_INTERVAL'].to_i unless ENV['NATS_PING_INTERVAL'].nil?
       opts[:max_outstanding_pings] = ENV['NATS_MAX_OUTSTANDING_PINGS'].to_i unless ENV['NATS_MAX_OUTSTANDING_PINGS'].nil?

--- a/lib/nats/io/client.rb
+++ b/lib/nats/io/client.rb
@@ -227,7 +227,7 @@ module NATS
       opts[:pedantic] = false if opts[:pedantic].nil?
       opts[:reconnect] = true if opts[:reconnect].nil?
       opts[:old_style_request] = false if opts[:old_style_request].nil?
-      opts[:discover_missing_cluster_servers] = true if opts[:discover_missing_cluster_servers].nil?
+      opts[:ignore_discovered_urls] = false if opts[:ignore_discovered_urls].nil?
       opts[:reconnect_time_wait] = NATS::IO::RECONNECT_TIME_WAIT if opts[:reconnect_time_wait].nil?
       opts[:max_reconnect_attempts] = NATS::IO::MAX_RECONNECT_ATTEMPTS if opts[:max_reconnect_attempts].nil?
       opts[:ping_interval] = NATS::IO::DEFAULT_PING_INTERVAL if opts[:ping_interval].nil?
@@ -238,7 +238,7 @@ module NATS
       opts[:pedantic] = ENV['NATS_PEDANTIC'].downcase == 'true' unless ENV['NATS_PEDANTIC'].nil?
       opts[:reconnect] = ENV['NATS_RECONNECT'].downcase == 'true' unless ENV['NATS_RECONNECT'].nil?
       opts[:reconnect_time_wait] = ENV['NATS_RECONNECT_TIME_WAIT'].to_i unless ENV['NATS_RECONNECT_TIME_WAIT'].nil?
-      opts[:discover_missing_cluster_servers] = ENV['NATS_DISCOVER_MISSING_CLUSTER_SERVERS'].downcase == 'true' unless ENV['NATS_DISCOVER_MISSING_CLUSTER_SERVERS'].nil?
+      opts[:ignore_discovered_urls] = ENV['NATS_IGNORE_DISCOVERED_URLS'].downcase == 'true' unless ENV['NATS_IGNORE_DISCOVERED_URLS'].nil?
       opts[:max_reconnect_attempts] = ENV['NATS_MAX_RECONNECT_ATTEMPTS'].to_i unless ENV['NATS_MAX_RECONNECT_ATTEMPTS'].nil?
       opts[:ping_interval] = ENV['NATS_PING_INTERVAL'].to_i unless ENV['NATS_PING_INTERVAL'].nil?
       opts[:max_outstanding_pings] = ENV['NATS_MAX_OUTSTANDING_PINGS'].to_i unless ENV['NATS_MAX_OUTSTANDING_PINGS'].nil?
@@ -809,7 +809,7 @@ module NATS
 
         # Detect any announced server that we might not be aware of...
         connect_urls = @server_info[:connect_urls]
-        if @options[:discover_missing_cluster_servers] && connect_urls
+        if !@options[:ignore_discovered_urls] && connect_urls
           srvs = []
           connect_urls.each do |url|
             scheme = client_using_secure_connection? ? "tls" : "nats"

--- a/lib/nats/io/client.rb
+++ b/lib/nats/io/client.rb
@@ -227,6 +227,7 @@ module NATS
       opts[:pedantic] = false if opts[:pedantic].nil?
       opts[:reconnect] = true if opts[:reconnect].nil?
       opts[:old_style_request] = false if opts[:old_style_request].nil?
+      opts[:detect_missing_announced_server] = true if opts[:detect_missing_announced_server].nil?
       opts[:reconnect_time_wait] = NATS::IO::RECONNECT_TIME_WAIT if opts[:reconnect_time_wait].nil?
       opts[:max_reconnect_attempts] = NATS::IO::MAX_RECONNECT_ATTEMPTS if opts[:max_reconnect_attempts].nil?
       opts[:ping_interval] = NATS::IO::DEFAULT_PING_INTERVAL if opts[:ping_interval].nil?
@@ -237,6 +238,7 @@ module NATS
       opts[:pedantic] = ENV['NATS_PEDANTIC'].downcase == 'true' unless ENV['NATS_PEDANTIC'].nil?
       opts[:reconnect] = ENV['NATS_RECONNECT'].downcase == 'true' unless ENV['NATS_RECONNECT'].nil?
       opts[:reconnect_time_wait] = ENV['NATS_RECONNECT_TIME_WAIT'].to_i unless ENV['NATS_RECONNECT_TIME_WAIT'].nil?
+      opts[:detect_missing_announced_server] = ENV['NATS_DETECT_MISSING_ANNOUNCED_SERVER'].downcase == 'true' unless ENV['NATS_DETECT_MISSING_ANNOUNCED_SERVER'].nil?
       opts[:max_reconnect_attempts] = ENV['NATS_MAX_RECONNECT_ATTEMPTS'].to_i unless ENV['NATS_MAX_RECONNECT_ATTEMPTS'].nil?
       opts[:ping_interval] = ENV['NATS_PING_INTERVAL'].to_i unless ENV['NATS_PING_INTERVAL'].nil?
       opts[:max_outstanding_pings] = ENV['NATS_MAX_OUTSTANDING_PINGS'].to_i unless ENV['NATS_MAX_OUTSTANDING_PINGS'].nil?
@@ -807,7 +809,7 @@ module NATS
 
         # Detect any announced server that we might not be aware of...
         connect_urls = @server_info[:connect_urls]
-        if connect_urls
+        if @options[:detect_missing_announced_server] && connect_urls
           srvs = []
           connect_urls.each do |url|
             scheme = client_using_secure_connection? ? "tls" : "nats"

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -82,7 +82,7 @@ describe 'Client - Specification' do
     s.start_server(true)
 
     nc = NATS::Client.new
-    nc.connect(servers: [@s.uri], detect_missing_announced_server: false)
+    nc.connect(servers: [@s.uri], discover_missing_cluster_servers: false)
 
     expect(nc.server_pool.length).to eq(1)
 

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -82,7 +82,7 @@ describe 'Client - Specification' do
     s.start_server(true)
 
     nc = NATS::Client.new
-    nc.connect(servers: [@s.uri], discover_missing_cluster_servers: false)
+    nc.connect(servers: [@s.uri], ignore_discovered_urls: true)
 
     expect(nc.server_pool.length).to eq(1)
 

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -18,7 +18,7 @@ require 'monitor'
 describe 'Client - Specification' do
 
   before(:each) do
-    @s = NatsServerControl.new("nats://127.0.0.1:4522")
+    @s = NatsServerControl.new("nats://127.0.0.1:4522", "/tmp/test-nats.pid", "--cluster nats://127.0.0.1:4248 --cluster_name test-cluster")
     @s.start_server(true)
   end
 
@@ -62,6 +62,32 @@ describe 'Client - Specification' do
       nc.connect("127.0.0.1:4522")
       nc.close
     end.to_not raise_error
+  end
+
+  it 'supports new server announcement discovery' do
+    s = NatsServerControl.new("nats://127.0.0.1:5223", "/tmp/test-nats-2.pid", "--cluster nats://127.0.0.1:5248 --cluster_name test-cluster --routes nats://127.0.0.1:4248")
+    s.start_server(true)
+
+    nc = NATS::Client.new
+    nc.connect(servers: [@s.uri])
+
+    expect(nc.server_pool.length).to be > 1
+
+    s.kill_server
+    nc.close
+  end
+
+  it 'supports skipping new server announcement discovery' do
+    s = NatsServerControl.new("nats://127.0.0.1:5223", "/tmp/test-nats-2.pid", "--cluster nats://127.0.0.1:5248 --cluster_name test-cluster --routes nats://127.0.0.1:4248")
+    s.start_server(true)
+
+    nc = NATS::Client.new
+    nc.connect(servers: [@s.uri], detect_missing_announced_server: false)
+
+    expect(nc.server_pool.length).to eq(1)
+
+    s.kill_server
+    nc.close
   end
 
   it 'should support custom inbox prefixes' do


### PR DESCRIPTION
We have cases where we'd like to disable this behavior.

Specifically we had cases where this would try to connect using less-preferred addressing, so we'd like the ability to just turn it off.

I wanted to see if you'd be receptive to this change. If so, I can look more into writing some specs, docs for this as well!