### PR TITLE
Fixes NATS::NUID::DIGITS not being Ractor safe

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,27 @@ loop do
 end
 ```
 
+## Ractor Usage
+
+Using NATS within a Ractor requires URI 0.11.0 or greater to be installed.
+
+```ruby
+Ractor.new do
+  ractor_nats = NATS.connect('demo.nats.io')
+
+  ractor_nats.subscribe('foo') do |msg, reply|
+    puts "Received on '#{msg.subject}': '#{msg.data}' with headers: #{msg.header}"
+    ractor_nats.publish(reply, 'baz')
+  end
+
+  sleep
+end
+
+nats = NATS.connect('demo.nats.io')
+response = nats.request('foo', 'bar', timeout: 0.5)
+puts response.data
+```
+
 ## TLS
 
 It is possible to setup a custom TLS connection to NATS by passing

--- a/lib/nats/nuid.rb
+++ b/lib/nats/nuid.rb
@@ -15,7 +15,7 @@ require 'securerandom'
 
 module NATS
   class NUID
-    DIGITS = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz'.split('')
+    DIGITS        = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz'.split('')
     BASE          = 62
     PREFIX_LENGTH = 12
     SEQ_LENGTH    = 10
@@ -24,6 +24,8 @@ module NATS
     MIN_INC       = 33
     MAX_INC       = 333
     INC = MAX_INC - MIN_INC
+
+    Ractor.make_shareable(DIGITS) if defined?(Ractor)
 
     def initialize
       @prand    = Random.new


### PR DESCRIPTION
Resolves an issue with `NATS::NUID::DIGITS` not being able to be shared across Ractors.