### PR TITLE
Show ellipsis when truncating data in message

### DIFF
--- a/lib/nats/io/msg.rb
+++ b/lib/nats/io/msg.rb
@@ -50,7 +50,9 @@ module NATS
 
     def inspect
       hdr = ", header=#{@header}" if @header
-      "#<NATS::Msg(subject: \"#{@subject}\", reply: \"#{@reply}\", data: #{@data.slice(0, 10).inspect}#{hdr})>"
+      dot = '...' if @data.length > 10
+      dat = "#{data.slice(0, 10)}#{dot}"
+      "#<NATS::Msg(subject: \"#{@subject}\", reply: \"#{@reply}\", data: #{dat.inspect}#{hdr})>"
     end
   end
 end


### PR DESCRIPTION
After accusing the sender of sending incomplete messages, I realized it was on my end... 

Indicating the truncation would've saved me a little time... and animosity -- see how useful ellipses are?

I couldn't find any specs for inspect method, so figured you were cool w/manual testing

It works fine w/ > 10
#<NATS::Msg(subject: "v1...", reply: "", data: "YAMOUSSOUK...")>

and with exactly 10
#<NATS::Msg(subject: "v1...", reply: "", data: "COPENHAGEN")>

and with less
#<NATS::Msg(subject: "v1...", reply: "", data: "BANGKOK")>