### PR TITLE
Fork detection and automatic reconnect in child process

### DIFF
--- a/lib/nats/io/client.rb
+++ b/lib/nats/io/client.rb
@@ -229,7 +229,7 @@ module NATS
       @drain_t = nil
 
       # Keep track of all client instances to handle them after process forking in Ruby 3.1+
-      INSTANCES[self] = self
+      INSTANCES[self] = self if !defined?(Ractor) || Ractor.current == Ractor.main # Ractors doesn't work in forked processes
     end
 
     # Establishes a connection to NATS.

--- a/lib/nats/io/client.rb
+++ b/lib/nats/io/client.rb
@@ -1066,6 +1066,8 @@ module NATS
     end
 
     def send_command(command)
+      raise NATS::IO::ConnectionClosedError if closed?
+
       @pending_size += command.bytesize
       @pending_queue << command
 

--- a/lib/nats/io/errors.rb
+++ b/lib/nats/io/errors.rb
@@ -61,6 +61,9 @@ module NATS
 
     # When a fork is detected, but the client is not configured to re-connect automatically.
     class ForkDetectedError < Error; end
+
+    # When tried to send command after connection has been closed.
+    class ConnectionClosedError < Error; end
   end
 
   # Timeout is raised when the client gives up waiting for a response from a service.

--- a/lib/nats/io/errors.rb
+++ b/lib/nats/io/errors.rb
@@ -58,6 +58,9 @@ module NATS
 
     # When drain takes too long to complete.
     class DrainTimeoutError < Error; end
+
+    # When a fork is detected, but the client is not configured to re-connect automatically.
+    class ForkDetectedError < Error; end
   end
 
   # Timeout is raised when the client gives up waiting for a response from a service.

--- a/sig/nats/io/client.rbs
+++ b/sig/nats/io/client.rbs
@@ -17,6 +17,8 @@ module NATS
     include MonitorMixin
     include Status
 
+    @ruby_pid: Integer
+
     attr_reader status: Integer
     attr_reader server_info: Hash[Symbol, untyped]
     attr_reader server_pool: Array[untyped]

--- a/sig/nats/io/client.rbs
+++ b/sig/nats/io/client.rbs
@@ -17,8 +17,6 @@ module NATS
     include MonitorMixin
     include Status
 
-    @ruby_pid: Integer
-
     attr_reader status: Integer
     attr_reader server_info: Hash[Symbol, untyped]
     attr_reader server_pool: Array[untyped]
@@ -44,6 +42,8 @@ module NATS
 
     SUB_OP: 'SUB'
     EMPTY_MSG: ''
+
+    INSTANCES: ObjectSpace::WeakMap
 
     @options: Hash[Symbol, untyped]
 

--- a/spec/client_fork_spec.rb
+++ b/spec/client_fork_spec.rb
@@ -1,0 +1,111 @@
+# Copyright 2016-2018 The NATS Authors
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+return unless Process.respond_to?(:fork) # Skip if fork is not supported
+
+require 'spec_helper'
+
+describe 'Client - Fork detection' do
+
+  before(:all) do
+    @s = NatsServerControl.new
+    @s.start_server(true)
+  end
+
+  after(:all) do
+    @s.kill_server
+  end
+
+  class Component
+    attr_reader  :nats, :options
+    attr_accessor :msgs
+
+    def initialize(options={})
+      @nats = NATS::IO::Client.new
+      @msgs = []
+      @options = options
+    end
+
+    def connect!
+      @nats.connect(@options)
+    end
+  end
+
+  let(:options) { {} }
+  let!(:component) { Component.new(options).tap(&:connect!) }
+
+  it 'should be able to publish messages from child process after forking' do
+    received = nil
+    component.nats.subscribe("forked-topic") do |msg|
+      received = msg.data
+    end
+
+    pid = fork do
+      component.nats.publish("forked-topic", "hey from the child process")
+      component.nats.flush
+    end
+    Process.wait(pid)
+    expect($?.exitstatus).to be_zero
+    expect(received).to eq("hey from the child process")
+  end
+
+  it 'should be able to receive messages from child process after forking' do
+    from_child, to_parent = IO.pipe
+    from_parent, to_child = IO.pipe
+
+    pid = fork do # child process
+      to_child.close; from_child.close # close unused ends
+
+      component.nats.subscribe("forked-topic") do |msg|
+        to_parent.write(msg.data)
+      end
+      component.nats.flush
+
+      to_parent.puts("proceed")
+
+      from_parent.gets
+      to_parent.close; from_parent.close
+    end
+
+    # parent process
+    to_parent.close; from_parent.close # close unused ends
+
+    from_child.gets
+    component.nats.publish("forked-topic", "hey from the parent process")
+    component.nats.flush
+
+    to_child.puts("proceed")
+
+    result = from_child.read
+    expect(result).to eq("hey from the parent process")
+
+    to_child.close; from_child.close
+    Process.wait(pid)
+  end
+
+  context "when reconnection is disabled" do
+    let(:options) { { reconnect: false } }
+
+    it "raises an error in child process after fork is detected" do
+      expect do
+        pid = fork do
+          component.nats.publish("topic", "whatever")
+          component.nats.flush
+        end
+        Process.wait(pid)
+        expect($?.exitstatus).to be_nonzero # child process should exit with error
+      end.to output(/NATS::IO::ForkDetectedError/).to_stderr_from_any_process
+    end
+  end
+end

--- a/spec/client_fork_spec.rb
+++ b/spec/client_fork_spec.rb
@@ -12,7 +12,8 @@
 # limitations under the License.
 #
 
-return unless Process.respond_to?(:fork) # Skip if fork is not supported
+return unless Process.respond_to?(:fork) # Skip if fork is not supported (Windows, JRuby, etc)
+return unless Process.respond_to?(:_fork) # Skip if around fork callbacks are not supported (before Ruby 3.1)
 
 require 'spec_helper'
 

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -303,11 +303,11 @@ describe 'Client - Specification' do
 
     pub_thread = Thread.new do
       1.upto(10000).each do |n|
-        nats.publish("bar.#{n}", "A" * 10)
+        nats.publish("bar.#{n}", "A" * 10) unless nats.closed?
       end
       sleep 0.01
       10001.upto(20000).each do |n|
-        nats.publish("bar.#{n}", "B" * 10)
+        nats.publish("bar.#{n}", "B" * 10) unless nats.closed?
       end
     end
     pub_thread.abort_on_exception = true

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -303,17 +303,17 @@ describe 'Client - Specification' do
 
     pub_thread = Thread.new do
       1.upto(10000).each do |n|
-        nats.publish("bar.#{n}", "A" * 10) unless nats.closed?
+        mon.synchronize { nats.publish("bar.#{n}", "A" * 10) unless nats.closed? }
       end
       sleep 0.01
       10001.upto(20000).each do |n|
-        nats.publish("bar.#{n}", "B" * 10) unless nats.closed?
+        mon.synchronize { nats.publish("bar.#{n}", "B" * 10) unless nats.closed? }
       end
     end
     pub_thread.abort_on_exception = true
 
-    nats.close
     mon.synchronize do
+      nats.close
       test_is_done.wait(1)
     end
 


### PR DESCRIPTION
**The problem**: sometimes people make “global” NATS clients in their app initializers and they are using either Unicorn or clustered Puma as application server for running their applications. In that case that client silently stops working. This happens because after fork the child process has only main thread, other threads aren't copied (see [fork docs](https://ruby-doc.org/core-3.0.0/Process.html#method-c-fork)).

**Solution**: use ability to hook into forking via `Process.fork` (since Ruby 3.1) to re-initialize client (re-creating all auxiliary threads) and establish new connection to the NATS server/cluster (thus avoiding problems with multiple processes using the same connection via the same descriptor and getting corrupted data as a result) 

Implementation notes:

  - all existing subscriptions are still continue to work only in the parent process. Child process doesn't have any subscriptions (and, probably, shouldn't)

    > Note: currently subscriptions aren't tracked after creation anyway (it is at the mercy of the calling application), there is only thread being created to handle incoming messages.

In this pull request:

 - [x] Fork detection and client re-initialization and re-connection
 - [x] Specs for subscriptions
 - [x] Specs for requests and responses
 - [x] Specs for jetstreams