### PR TITLE
Delayed connection: allow to initialize client without connecting

### DIFF
--- a/lib/nats/io/client.rb
+++ b/lib/nats/io/client.rb
@@ -61,6 +61,9 @@ module NATS
   # the connection is manually closed then it will reach the CLOSED
   # connection state after which it will not reconnect again.
   module Status
+    # When client was just initialized.
+    NOT_YET_CONNECTED = -1
+
     # When the client is not actively connected.
     DISCONNECTED = 0
 
@@ -127,8 +130,9 @@ module NATS
       def after_fork
         INSTANCES.each do |client|
           if client.options[:reconnect]
-            client.close
-            client.connect(client.uri, client.options)
+            was_connected = !client.disconnected?
+            client.send(:close_connection, Status::DISCONNECTED, true)
+            client.connect if was_connected
           else
             client.send(:err_cb_call, self, NATS::IO::ForkDetectedError, nil)
             client.close
@@ -139,9 +143,10 @@ module NATS
       end
     end
 
-    def initialize
-      super # required to initialize monitor
-      @options = nil
+    def initialize(uri = nil, opts = {})
+      super() # required to initialize monitor
+      @initial_uri = uri
+      @initial_options = opts
 
       # Read/Write IO
       @io = nil
@@ -165,7 +170,7 @@ module NATS
       @uri = nil
       @server_pool = []
 
-      @status = DISCONNECTED
+      @status = NOT_YET_CONNECTED
 
       # Subscriptions
       @subs = { }
@@ -228,20 +233,33 @@ module NATS
       # Draining
       @drain_t = nil
 
+      # Prepare for calling connect or automatic delayed connection
+      parse_and_validate_options if uri || opts.any?
+
       # Keep track of all client instances to handle them after process forking in Ruby 3.1+
       INSTANCES[self] = self if !defined?(Ractor) || Ractor.current == Ractor.main # Ractors doesn't work in forked processes
     end
 
-    # Establishes a connection to NATS.
+    # Prepare connecting to NATS, but postpone real connection until first usage.
     def connect(uri=nil, opts={})
+      if uri || opts.any?
+        @initial_uri = uri
+        @initial_options = opts
+      end
+
       synchronize do
         # In case it has been connected already, then do not need to call this again.
         return if @connect_called
         @connect_called = true
       end
 
-      @ruby_pid = Process.pid # For fork detection
+      parse_and_validate_options
+      establish_connection!
 
+      self
+    end
+
+    private def parse_and_validate_options
       # Reset these in case we have reconnected via fork.
       @server_pool = []
       @resp_sub = nil
@@ -257,8 +275,10 @@ module NATS
       }
 
       # Convert URI to string if needed.
-      @uri = uri
+      uri = @initial_uri.dup
       uri = uri.to_s if uri.is_a?(URI)
+
+      opts = @initial_options.dup
 
       case uri
       when String
@@ -339,6 +359,12 @@ module NATS
       @inbox_prefix = opts.fetch(:custom_inbox_prefix, @inbox_prefix)
 
       validate_settings!
+
+      self
+    end
+
+    private def establish_connection!
+      @ruby_pid = Process.pid # For fork detection
 
       srv = nil
       begin
@@ -762,6 +788,10 @@ module NATS
       connected? ? @uri : nil
     end
 
+    def disconnected?
+      @status == DISCONNECTED
+    end
+
     def connected?
       @status == CONNECTED
     end
@@ -1075,6 +1105,8 @@ module NATS
 
     def send_command(command)
       raise NATS::IO::ConnectionClosedError if closed?
+
+      establish_connection! if status == NOT_YET_CONNECTED
 
       @pending_size += command.bytesize
       @pending_queue << command

--- a/lib/nats/io/client.rb
+++ b/lib/nats/io/client.rb
@@ -61,9 +61,6 @@ module NATS
   # the connection is manually closed then it will reach the CLOSED
   # connection state after which it will not reconnect again.
   module Status
-    # When client was just initialized.
-    NOT_YET_CONNECTED = -1
-
     # When the client is not actively connected.
     DISCONNECTED = 0
 
@@ -170,7 +167,7 @@ module NATS
       @uri = nil
       @server_pool = []
 
-      @status = NOT_YET_CONNECTED
+      @status = nil
 
       # Subscriptions
       @subs = { }
@@ -273,6 +270,7 @@ module NATS
         out_bytes: 0,
         reconnects: 0
       }
+      @status = DISCONNECTED
 
       # Convert URI to string if needed.
       uri = @initial_uri.dup
@@ -789,7 +787,7 @@ module NATS
     end
 
     def disconnected?
-      @status == DISCONNECTED
+      !@status or @status == DISCONNECTED
     end
 
     def connected?
@@ -1106,7 +1104,7 @@ module NATS
     def send_command(command)
       raise NATS::IO::ConnectionClosedError if closed?
 
-      establish_connection! if status == NOT_YET_CONNECTED
+      establish_connection! unless status
 
       @pending_size += command.bytesize
       @pending_queue << command

--- a/spec/client_delayed_connection_spec.rb
+++ b/spec/client_delayed_connection_spec.rb
@@ -15,7 +15,7 @@
 require 'spec_helper'
 require 'monitor'
 
-describe 'Client - Connection' do
+describe 'Client - Delayed Connection' do
   let(:server) do
     NatsServerControl.new("nats://127.0.0.1:4522", "/tmp/test-nats.pid", "--cluster nats://127.0.0.1:4248 --cluster_name test-cluster")
   end

--- a/spec/client_delayed_connection_spec.rb
+++ b/spec/client_delayed_connection_spec.rb
@@ -1,0 +1,57 @@
+# Copyright 2016-2018 The NATS Authors
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+require 'monitor'
+
+describe 'Client - Connection' do
+  let(:server) do
+    NatsServerControl.new("nats://127.0.0.1:4522", "/tmp/test-nats.pid", "--cluster nats://127.0.0.1:4248 --cluster_name test-cluster")
+  end
+
+  context "when server isn't available" do
+    it 'should not raise error on client init' do
+      expect do
+        nc = NATS::Client.new(servers: [server.uri])
+        nc.close
+      end.to_not raise_error
+    end
+
+    it 'should raise error on connect' do
+      expect do
+        nc = NATS::Client.new
+        nc.connect(servers: [server.uri])
+        nc.close
+      end.to raise_error(Errno::ECONNREFUSED)
+    end
+  end
+
+  context "when server is available" do
+    before { server.start_server(true) }
+    after { server.kill_server && sleep(0.1) }
+
+    it "connects to the server on the first command and works" do
+      nc = NATS::Client.new(servers: [server.uri])
+      nc.connect
+      nc.subscribe("service") do |msg|
+        msg.respond("pong")
+      end
+
+      resp = nc.request("service", "ping")
+      expect(resp.data).to eq("pong")
+
+      nc.close
+    end
+  end
+end


### PR DESCRIPTION
Made on top of #114, diff will become much smaller after merging it.

Allow to initialize client with connection options, and don't require to connect to the server immediately, instead establish connection only on the first usage.

It can assist fork detection (which reconnects after fork) by not connecting to the server in the parent process in the first place. Use case: people tend to create global client (`$nats = NATS.connect`) on app initialization, but use it only during runtime (after fork).

Before:

```ruby
nats = NATS::Client.new
nats.connect("nats://127.0.0.1:4524") # Required. Establishes connection
nats.subscribe("whatever") { |msg| … } # Uses connection
```

After:

```ruby
nats = NATS::Client.new("nats://127.0.0.1:4524") # Pass connection options here. Doesn't establish connection
nats.subscribe("whatever") { |msg| … } # Establishes and uses connection
# Or you can optionally call nats.connect without arguments to force establishing connection
```

Progress:

 - [x] implementation
 - [x] specs
