### PR TITLE
Handling subscription messages in a thread pool

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,3 +11,7 @@ end
 group :v2 do
   gem 'nkeys'
 end
+
+group :development do
+  gem 'ruby-progressbar'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,31 +2,33 @@ PATH
   remote: .
   specs:
     nats-pure (2.3.0)
+      concurrent-ruby (~> 1.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
     base32 (0.3.4)
-    benchmark-ips (2.10.0)
+    benchmark-ips (2.12.0)
+    concurrent-ruby (1.2.2)
     diff-lcs (1.5.0)
     ed25519 (1.3.0)
     nkeys (0.1.0)
       base32 (~> 0.3)
       ed25519 (~> 1.2)
     rake (13.0.6)
-    rspec (3.11.0)
-      rspec-core (~> 3.11.0)
-      rspec-expectations (~> 3.11.0)
-      rspec-mocks (~> 3.11.0)
-    rspec-core (3.11.0)
-      rspec-support (~> 3.11.0)
-    rspec-expectations (3.11.1)
+    rspec (3.12.0)
+      rspec-core (~> 3.12.0)
+      rspec-expectations (~> 3.12.0)
+      rspec-mocks (~> 3.12.0)
+    rspec-core (3.12.2)
+      rspec-support (~> 3.12.0)
+    rspec-expectations (3.12.3)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.11.0)
-    rspec-mocks (3.11.1)
+      rspec-support (~> 3.12.0)
+    rspec-mocks (3.12.5)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.11.0)
-    rspec-support (3.11.1)
+      rspec-support (~> 3.12.0)
+    rspec-support (3.12.0)
 
 PLATFORMS
   ruby
@@ -39,4 +41,4 @@ DEPENDENCIES
   rspec
 
 BUNDLED WITH
-   2.2.22
+   2.4.10

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,9 +29,10 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
     rspec-support (3.12.0)
+    ruby-progressbar (1.13.0)
 
 PLATFORMS
-  ruby
+  x86_64-linux
 
 DEPENDENCIES
   benchmark-ips
@@ -39,6 +40,7 @@ DEPENDENCIES
   nkeys
   rake
   rspec
+  ruby-progressbar
 
 BUNDLED WITH
    2.4.10

--- a/benchmark/pub_sub_perf.rb
+++ b/benchmark/pub_sub_perf.rb
@@ -13,6 +13,8 @@
 #
 
 require 'optparse'
+require 'concurrent'
+require 'ruby-progressbar'
 
 $:.unshift File.expand_path('../../lib', __FILE__)
 require 'nats/io/client'
@@ -20,16 +22,15 @@ require 'nats/io/client'
 $count = 100000
 $batch = 100
 
-$delay = 0.00001
-$dmin  = 0.00001
+$subscriptions = 1
+$concurrency = 1
 
-TRIP  = (2*1024*1024)
+$delay = 0.00001
+
 TSIZE = 4*1024
 
 $sub  = 'test'
 $data_size = 16
-
-$hash  = 2500
 
 $stdout.sync = true
 
@@ -43,14 +44,30 @@ parser = OptionParser.new do |opts|
   opts.on("-s SIZE",    "Message size (default: #{$data_size})") { |size| $data_size = size.to_i }
   opts.on("-S SUBJECT", "Send subject (default: (#{$sub})")      { |sub| $sub = sub }
   opts.on("-b BATCH",   "Batch size (default: (#{$batch})")      { |batch| $batch = batch.to_i }
+  opts.on("-c SUBSCRIPTIONS", "Subscription number (default: (#{$subscriptions})") { |subscriptions| $subscriptions = subscriptions.to_i }
+  opts.on("-t CONCURRENCY", "Subscription processing concurrency (default: (#{$concurrency})") { |concurrency| $concurrency = concurrency.to_i }
 end
 
 parser.parse(ARGV)
 
-trap("TERM") { exit! }
-trap("INT")  { exit! }
-
 $data = Array.new($data_size) { "%01x" % rand(16) }.join('').freeze
+
+puts "Sending #{$count} messages of size #{$data.size} bytes on [#{$sub}], receiving each in #{$subscriptions} subscriptions"
+
+$progressbar = ProgressBar.create(title: "Received", total: $count*$subscriptions, format: '%t: |%B| %p%% %a %e', autofinish: false, throttle_rate: 0.1)
+
+def results
+  elapsed  = Time.now - $start
+  mbytes = sprintf("%.1f", (($data_size*$received)/elapsed)/(1024*1024))
+  <<~MSG
+
+    Test completed: #{($received/elapsed).ceil} received msgs/sec (#{mbytes} MB/sec)
+    Received #{$received} messages in #{elapsed} seconds
+  MSG
+end
+
+trap("TERM") { puts results; exit! }
+trap("INT")  { puts results; exit! }
 
 nats = NATS::IO::Client.new
 nats.connect
@@ -58,29 +75,33 @@ nats.connect
 $batch = 10 if $data_size >= TSIZE
 
 $received = 0
-nats.subscribe($sub) { $received += 1; print('+') if $received.modulo($hash) == 0 }
+
+$subscriptions.times do
+  subscription = nats.subscribe($sub) { $received += 1; $progressbar.progress = $received }
+  subscription.processing_concurrency = $concurrency
+end
 
 $start   = Time.now
 $to_send = $count
 
-puts "Sending #{$count} messages of size #{$data.size} bytes on [#{$sub}]"
-
 loop do
   (0..$batch).each do
     $to_send -= 1
-    if $to_send == 0
-      nats.publish($sub, $data)
-      nats.flush
+    nats.publish($sub, $data)
 
-      elapsed = Time.now - $start
-      mbytes = sprintf("%.1f", (($data_size*$count)/elapsed)/(1024*1024))
-      puts "\nTest completed : #{($count/elapsed).ceil} sent/received msgs/sec (#{mbytes} MB/sec)\n"
-      puts "Received #{$received} messages\n"
-      exit
-    else
-      nats.publish($sub, $data)
-    end
+    break if $to_send.zero?
+
     sleep $delay if $to_send.modulo(1000) == 0
-    print('#') if $to_send.modulo($hash) == 0
   end
+  break if $to_send.zero?
 end
+
+# Finish and let client to process everything
+finished = Concurrent::Event.new
+nats.on_close { finished.set }
+nats.flush(300)
+nats.drain
+finished.wait
+$progressbar.finish
+
+puts results

--- a/lib/nats/io/client.rb
+++ b/lib/nats/io/client.rb
@@ -26,6 +26,7 @@ require 'json'
 require 'monitor'
 require 'uri'
 require 'securerandom'
+require 'concurrent'
 
 begin
   require "openssl"
@@ -99,7 +100,7 @@ module NATS
     include MonitorMixin
     include Status
 
-    attr_reader :status, :server_info, :server_pool, :options, :connected_server, :stats, :uri
+    attr_reader :status, :server_info, :server_pool, :options, :connected_server, :stats, :uri, :subscription_executor
 
     DEFAULT_PORT = 4222
     DEFAULT_URI = ("nats://localhost:#{DEFAULT_PORT}".freeze)
@@ -522,41 +523,6 @@ module NATS
         cond = sub.new_cond
         sub.wait_for_msgs_cond = cond
       end
-
-      # Async subscriptions each own a single thread for the
-      # delivery of messages.
-      # FIXME: Support shared thread pool with configurable limits
-      # to better support case of having a lot of subscriptions.
-      sub.wait_for_msgs_t = Thread.new do
-        loop do
-          msg = sub.pending_queue.pop
-
-          cb = nil
-          sub.synchronize do
-
-            # Decrease pending size since consumed already
-            sub.pending_size -= msg.data.size
-            cb = sub.callback
-          end
-
-          begin
-            # Note: Keep some of the alternative arity versions to slightly
-            # improve backwards compatibility.  Eventually fine to deprecate
-            # since recommended version would be arity of 1 to get a NATS::Msg.
-            case cb.arity
-            when 0 then cb.call
-            when 1 then cb.call(msg)
-            when 2 then cb.call(msg.data, msg.reply)
-            when 3 then cb.call(msg.data, msg.reply, msg.subject)
-            else cb.call(msg.data, msg.reply, msg.subject, msg.header)
-            end
-          rescue => e
-            synchronize do
-              err_cb_call(self, e, sub) if @err_cb
-            end
-          end
-        end
-      end if callback
 
       sub
     end
@@ -1052,12 +1018,8 @@ module NATS
             # Only dispatch message when sure that it would not block
             # the main read loop from the parser.
             msg = Msg.new(subject: subject, reply: reply, data: data, header: hdr, nc: self, sub: sub)
-            sub.pending_queue << msg
 
-            # For sync subscribers, signal that there is a new message.
-            sub.wait_for_msgs_cond.signal if sub.wait_for_msgs_cond
-
-            sub.pending_size += data.size
+            sub.dispatch(msg)
           end
         end
       end
@@ -1132,12 +1094,6 @@ module NATS
       synchronize do
         sub.max = opt_max
         @subs.delete(sid) unless (sub.max && (sub.received < sub.max))
-
-        # Stop messages delivery thread for async subscribers
-        if sub.wait_for_msgs_t && sub.wait_for_msgs_t.alive?
-          sub.wait_for_msgs_t.exit
-          sub.pending_queue.clear
-        end
       end
 
       sub.synchronize do
@@ -1192,11 +1148,6 @@ module NATS
 
         to_delete.each do |sub|
           @subs.delete(sub.sid)
-          # Stop messages delivery thread for async subscribers
-          if sub.wait_for_msgs_t && sub.wait_for_msgs_t.alive?
-            sub.wait_for_msgs_t.exit
-            sub.pending_queue.clear
-          end
         end
         to_delete.clear
 
@@ -1639,12 +1590,6 @@ module NATS
         end if should_flush
 
         # Destroy any remaining subscriptions.
-        @subs.each do |_, sub|
-          if sub.wait_for_msgs_t && sub.wait_for_msgs_t.alive?
-            sub.wait_for_msgs_t.exit
-            sub.pending_queue.clear
-          end
-        end
         @subs.clear
 
         if do_cbs
@@ -1666,15 +1611,24 @@ module NATS
     def start_threads!
       # Reading loop for gathering data
       @read_loop_thread = Thread.new { read_loop }
+      @read_loop_thread.name = "nats:read_loop"
       @read_loop_thread.abort_on_exception = true
 
       # Flusher loop for sending commands
       @flusher_thread = Thread.new { flusher_loop }
+      @flusher_thread.name = "nats:flusher_loop"
       @flusher_thread.abort_on_exception = true
 
       # Ping interval handling for keeping alive the connection
       @ping_interval_thread = Thread.new { ping_interval_loop }
+      @ping_interval_thread.name = "nats:ping_loop"
       @ping_interval_thread.abort_on_exception = true
+
+      # Subscription handling thread pool
+      @subscription_executor = Concurrent::ThreadPoolExecutor.new(
+        name: 'nats:subscription', # threads will be given names like nats:subscription-worker-1
+        max_threads: NATS::IO::DEFAULT_TOTAL_SUB_CONCURRENCY,
+      )
     end
 
     # Prepares requests subscription that handles the responses
@@ -1692,25 +1646,20 @@ module NATS
       @resp_sub.pending_msgs_limit = NATS::IO::DEFAULT_SUB_PENDING_MSGS_LIMIT
       @resp_sub.pending_bytes_limit = NATS::IO::DEFAULT_SUB_PENDING_BYTES_LIMIT
       @resp_sub.pending_queue = SizedQueue.new(@resp_sub.pending_msgs_limit)
-      @resp_sub.wait_for_msgs_t = Thread.new do
-        loop do
-          msg = @resp_sub.pending_queue.pop
-          @resp_sub.pending_size -= msg.data.size
+      @resp_sub.callback = proc do |msg|
+        # Pick the token and signal the request under the mutex
+        # from the subscription itself.
+        token = msg.subject.split('.').last
+        future = nil
+        synchronize do
+          future = @resp_map[token][:future]
+          @resp_map[token][:response] = msg
+        end
 
-          # Pick the token and signal the request under the mutex
-          # from the subscription itself.
-          token = msg.subject.split('.').last
-          future = nil
-          synchronize do
-            future = @resp_map[token][:future]
-            @resp_map[token][:response] = msg
-          end
-
-          # Signal back that the response has arrived
-          # in case the future has not been yet delete.
-          @resp_sub.synchronize do
-            future.signal if future
-          end
+        # Signal back that the response has arrived
+        # in case the future has not been yet delete.
+        @resp_sub.synchronize do
+          future.signal if future
         end
       end
 
@@ -1899,6 +1848,9 @@ module NATS
     # Default Pending Limits
     DEFAULT_SUB_PENDING_MSGS_LIMIT  = 65536
     DEFAULT_SUB_PENDING_BYTES_LIMIT = 65536 * 1024
+
+    DEFAULT_TOTAL_SUB_CONCURRENCY = 24
+    DEFAULT_SINGLE_SUB_CONCURRENCY = 1
 
     # Implementation adapted from https://github.com/redis/redis-rb
     class Socket

--- a/lib/nats/io/client.rb
+++ b/lib/nats/io/client.rb
@@ -1323,7 +1323,7 @@ module NATS
         @flush_queue.pop
 
         should_bail = synchronize do
-          @status != CONNECTED || @status == CONNECTING
+          (@status != CONNECTED && !draining? ) || @status == CONNECTING
         end
         return if should_bail
 

--- a/lib/nats/io/subscription.rb
+++ b/lib/nats/io/subscription.rb
@@ -28,14 +28,14 @@ module NATS
     include MonitorMixin
 
     attr_accessor :subject, :queue, :future, :callback, :response, :received, :max, :pending, :sid
-    attr_accessor :pending_queue, :pending_size, :wait_for_msgs_t, :wait_for_msgs_cond, :is_slow_consumer
+    attr_accessor :pending_queue, :pending_size, :wait_for_msgs_cond, :concurrency_semaphore
     attr_accessor :pending_msgs_limit, :pending_bytes_limit
     attr_accessor :nc
     attr_accessor :jsi
     attr_accessor :closed
 
-    def initialize
-      super # required to initialize monitor
+    def initialize(**opts)
+      super() # required to initialize monitor
       @subject  = ''
       @queue    = nil
       @future   = nil
@@ -53,11 +53,27 @@ module NATS
       @pending_size        = 0
       @pending_msgs_limit  = nil
       @pending_bytes_limit = nil
-      @wait_for_msgs_t     = nil
-      @is_slow_consumer    = false
 
       # Sync subscriber
       @wait_for_msgs_cond = nil
+
+      # To limit number of concurrent messages being processed (1 to only allow sequential processing)
+      @processing_concurrency = opts.fetch(:processing_concurrency, NATS::IO::DEFAULT_SINGLE_SUB_CONCURRENCY)
+    end
+
+    # Concurrency of message processing for a single subscription.
+    # 1 means sequential processing
+    # 2+ allow processed concurrently and possibly out of order.
+    def processing_concurrency=(value)
+      raise ArgumentError, "nats: subscription processing concurrency must be positive integer" unless value.positive?
+      return if @processing_concurrency == value
+
+      @processing_concurrency = value
+      @concurrency_semaphore = Concurrent::Semaphore.new(value)
+    end
+
+    def concurrency_semaphore
+      @concurrency_semaphore ||= Concurrent::Semaphore.new(@processing_concurrency)
     end
 
     # Auto unsubscribes the server by sending UNSUB command and throws away
@@ -87,6 +103,57 @@ module NATS
 
     def inspect
       "#<NATS::Subscription(subject: \"#{@subject}\", queue: \"#{@queue}\", sid: #{@sid})>"
+    end
+
+    def dispatch(msg)
+      pending_queue << msg
+      synchronize { self.pending_size += msg.data.size }
+
+      # For async subscribers, send message for processing to the thread pool.
+      enqueue_processing(@nc.subscription_executor) if callback
+
+      # For sync subscribers, signal that there is a new message.
+      wait_for_msgs_cond&.signal
+    end
+
+    def process(msg)
+      return unless callback
+
+      # Decrease pending size since consumed already
+      synchronize { self.pending_size -= msg.data.size }
+
+      begin
+        # Note: Keep some of the alternative arity versions to slightly
+        # improve backwards compatibility.  Eventually fine to deprecate
+        # since recommended version would be arity of 1 to get a NATS::Msg.
+        case callback.arity
+        when 0 then callback.call
+        when 1 then callback.call(msg)
+        when 2 then callback.call(msg.data, msg.reply)
+        when 3 then callback.call(msg.data, msg.reply, msg.subject)
+        else callback.call(msg.data, msg.reply, msg.subject, msg.header)
+        end
+      rescue => e
+        synchronize { nc.send(:err_cb_call, nc, e, self) }
+      end
+    end
+
+    # Send a message for its processing to a separate thread
+    def enqueue_processing(executor)
+      concurrency_semaphore.try_acquire || return # Previous message is being executed, let it finish and enqueue next one.
+      executor.post do
+        msg = pending_queue.pop(true)
+        process(msg)
+      rescue ThreadError # queue is empty
+        concurrency_semaphore.release
+      ensure
+        concurrency_semaphore.release
+        synchronize do
+          [concurrency_semaphore.available_permits, pending_queue.size].min.times do
+            enqueue_processing(executor)
+          end
+        end
+      end
     end
   end
 end

--- a/lib/nats/io/subscription.rb
+++ b/lib/nats/io/subscription.rb
@@ -148,10 +148,8 @@ module NATS
         concurrency_semaphore.release
       ensure
         concurrency_semaphore.release
-        synchronize do
-          [concurrency_semaphore.available_permits, pending_queue.size].min.times do
-            enqueue_processing(executor)
-          end
+        [concurrency_semaphore.available_permits, pending_queue.size].min.times do
+          enqueue_processing(executor)
         end
       end
     end

--- a/nats-pure.gemspec
+++ b/nats-pure.gemspec
@@ -29,4 +29,6 @@ Gem::Specification.new do |s|
 
   s.files = Dir['lib/**/*.rb']
   s.files += Dir['sig/**/*.rbs']
+
+  s.add_dependency "concurrent-ruby", "~> 1.0"
 end

--- a/sig/nats/io/client.rbs
+++ b/sig/nats/io/client.rbs
@@ -24,6 +24,7 @@ module NATS
     attr_reader connected_server: String?
     attr_reader stats: Hash[Symbol, Integer]
     attr_reader uri: String?
+    attr_reader subscription_executor: Concurrent::ThreadPoolExecutor?
 
     DEFAULT_PORT: 4222
     DEFAULT_URI: String
@@ -57,6 +58,7 @@ module NATS
     @flusher_thread: Thread?
     @read_loop_thread: Thread?
     @ping_interval_thread: Thread?
+    @subscription_executor: Concurrent::ThreadPoolExecutor?
 
     @subs: Hash[Symbol, untyped]
     @ssid: Integer

--- a/sig/nats/io/subscription.rbs
+++ b/sig/nats/io/subscription.rbs
@@ -14,9 +14,7 @@ module NATS
 
     attr_accessor pending_queue: Thread::SizedQueue?
     attr_accessor pending_size: Integer
-    attr_accessor wait_for_msgs_t: Thread?
     attr_accessor wait_for_msgs_cond: MonitorMixin::ConditionVariable?
-    attr_accessor is_slow_consumer: bool
 
     attr_accessor pending_msgs_limit: Integer?
     attr_accessor pending_bytes_limit: Integer?
@@ -24,6 +22,9 @@ module NATS
     attr_accessor nc: NATS::Client?
     attr_accessor jsi: NATS::JetStream::JS::Sub
     attr_accessor closed: bool?
+
+    attr_accessor processing_concurrency: Integer
+    attr_reader concurrency_semaphore: Concurrent::Semaphore
 
     def unsubscribe: (?Integer?) -> void
 


### PR DESCRIPTION
The problem: using separate thread for every subscription is resource heavy, reduces performance due to excess context switching, and limits number of subscriptions that can be created (it depends on the OS, but it is said that practically it is somewhere around few dozen thousands threads).

The solution: use [thread pools](https://ruby-concurrency.github.io/concurrent-ruby/master/file.thread_pools.html) to distribute message processing from all subscriptions to a reasonable number of threads. Also use [semaphores](https://ruby-concurrency.github.io/concurrent-ruby/master/Concurrent/Semaphore.html) to ensure that any given subscription messages are processed sequentially.

 - [x] Implementation
 - [x] Benchmarks

**Benchmarks**

I executed `benchmarks/pub_sub_perf.rb` in this pull request and current `main` sending 10 messages and receiving them in different number of subscriptions (from 1 to 30000).

![image](https://github.com/nats-io/nats-pure.rb/assets/264400/79aabc12-75e3-481d-9330-0ca1edd837df)


As can be seen, there is no difference in performance up to 5 000 subscriptions, then performance of single-thread-per-subscription start to degrade quickly. The practical limit for number of threads on my machine is somewhere above 32 000, so I didn't do benchmarking beyond 30 000 subscriptions. However, thread pool based version works totally fine on 100 000 subscriptions, for example.

<details>
<summary>Raw data</summary>

```csv
Subscriptions,Thread pool,Individual threads
1,0.22561474199756049,0.21783994200086454
5,0.22992107199752354,0.22141029100021115
10,0.23651741900175693,0.22182863399939379
50,0.24648931400224683,0.23073389499768382
100,0.26153432600040105,0.22641186799955904
500,0.35329902800003765,0.26661403700200026
1000,0.36710690700056148,0.31920890200126451
5000,0.90028256000005058,0.96799352699963492
10000,1.4961059820016089,2.2726283129995863
20000,2.0715542360012478,6.1912920100003248
30000,3.1422558439990098,11.099830663002649
```
</details>