### PR TITLE
Integrate with Rails Executor for subscription callbacks resource cleanup

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,9 @@ group :test do
   gem 'rake'
   gem 'rspec'
   gem 'benchmark-ips'
+  gem 'rails', require: false
+  gem 'activerecord', require: false
+  gem 'sqlite3', require: false
 end
 
 group :v2 do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,14 +7,142 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    actioncable (7.0.5)
+      actionpack (= 7.0.5)
+      activesupport (= 7.0.5)
+      nio4r (~> 2.0)
+      websocket-driver (>= 0.6.1)
+    actionmailbox (7.0.5)
+      actionpack (= 7.0.5)
+      activejob (= 7.0.5)
+      activerecord (= 7.0.5)
+      activestorage (= 7.0.5)
+      activesupport (= 7.0.5)
+      mail (>= 2.7.1)
+      net-imap
+      net-pop
+      net-smtp
+    actionmailer (7.0.5)
+      actionpack (= 7.0.5)
+      actionview (= 7.0.5)
+      activejob (= 7.0.5)
+      activesupport (= 7.0.5)
+      mail (~> 2.5, >= 2.5.4)
+      net-imap
+      net-pop
+      net-smtp
+      rails-dom-testing (~> 2.0)
+    actionpack (7.0.5)
+      actionview (= 7.0.5)
+      activesupport (= 7.0.5)
+      rack (~> 2.0, >= 2.2.4)
+      rack-test (>= 0.6.3)
+      rails-dom-testing (~> 2.0)
+      rails-html-sanitizer (~> 1.0, >= 1.2.0)
+    actiontext (7.0.5)
+      actionpack (= 7.0.5)
+      activerecord (= 7.0.5)
+      activestorage (= 7.0.5)
+      activesupport (= 7.0.5)
+      globalid (>= 0.6.0)
+      nokogiri (>= 1.8.5)
+    actionview (7.0.5)
+      activesupport (= 7.0.5)
+      builder (~> 3.1)
+      erubi (~> 1.4)
+      rails-dom-testing (~> 2.0)
+      rails-html-sanitizer (~> 1.1, >= 1.2.0)
+    activejob (7.0.5)
+      activesupport (= 7.0.5)
+      globalid (>= 0.3.6)
+    activemodel (7.0.5)
+      activesupport (= 7.0.5)
+    activerecord (7.0.5)
+      activemodel (= 7.0.5)
+      activesupport (= 7.0.5)
+    activestorage (7.0.5)
+      actionpack (= 7.0.5)
+      activejob (= 7.0.5)
+      activerecord (= 7.0.5)
+      activesupport (= 7.0.5)
+      marcel (~> 1.0)
+      mini_mime (>= 1.1.0)
+    activesupport (7.0.5)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      tzinfo (~> 2.0)
     base32 (0.3.4)
     benchmark-ips (2.12.0)
+    builder (3.2.4)
     concurrent-ruby (1.2.2)
+    crass (1.0.6)
+    date (3.3.3)
     diff-lcs (1.5.0)
     ed25519 (1.3.0)
+    erubi (1.12.0)
+    globalid (1.1.0)
+      activesupport (>= 5.0)
+    i18n (1.14.1)
+      concurrent-ruby (~> 1.0)
+    loofah (2.21.3)
+      crass (~> 1.0.2)
+      nokogiri (>= 1.12.0)
+    mail (2.8.1)
+      mini_mime (>= 0.1.1)
+      net-imap
+      net-pop
+      net-smtp
+    marcel (1.0.2)
+    method_source (1.0.0)
+    mini_mime (1.1.2)
+    minitest (5.18.0)
+    net-imap (0.3.4)
+      date
+      net-protocol
+    net-pop (0.1.2)
+      net-protocol
+    net-protocol (0.2.1)
+      timeout
+    net-smtp (0.3.3)
+      net-protocol
+    nio4r (2.5.9)
     nkeys (0.1.0)
       base32 (~> 0.3)
       ed25519 (~> 1.2)
+    nokogiri (1.15.2-x86_64-linux)
+      racc (~> 1.4)
+    racc (1.7.0)
+    rack (2.2.7)
+    rack-test (2.1.0)
+      rack (>= 1.3)
+    rails (7.0.5)
+      actioncable (= 7.0.5)
+      actionmailbox (= 7.0.5)
+      actionmailer (= 7.0.5)
+      actionpack (= 7.0.5)
+      actiontext (= 7.0.5)
+      actionview (= 7.0.5)
+      activejob (= 7.0.5)
+      activemodel (= 7.0.5)
+      activerecord (= 7.0.5)
+      activestorage (= 7.0.5)
+      activesupport (= 7.0.5)
+      bundler (>= 1.15.0)
+      railties (= 7.0.5)
+    rails-dom-testing (2.0.3)
+      activesupport (>= 4.2.0)
+      nokogiri (>= 1.6)
+    rails-html-sanitizer (1.6.0)
+      loofah (~> 2.21)
+      nokogiri (~> 1.14)
+    railties (7.0.5)
+      actionpack (= 7.0.5)
+      activesupport (= 7.0.5)
+      method_source
+      rake (>= 12.2)
+      thor (~> 1.0)
+      zeitwerk (~> 2.5)
     rake (13.0.6)
     rspec (3.12.0)
       rspec-core (~> 3.12.0)
@@ -30,17 +158,29 @@ GEM
       rspec-support (~> 3.12.0)
     rspec-support (3.12.0)
     ruby-progressbar (1.13.0)
+    sqlite3 (1.6.3-x86_64-linux)
+    thor (1.2.2)
+    timeout (0.3.2)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
+    websocket-driver (0.7.5)
+      websocket-extensions (>= 0.1.0)
+    websocket-extensions (0.1.5)
+    zeitwerk (2.6.8)
 
 PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  activerecord
   benchmark-ips
   nats-pure!
   nkeys
+  rails
   rake
   rspec
   ruby-progressbar
+  sqlite3
 
 BUNDLED WITH
    2.4.10

--- a/lib/nats/io/rails.rb
+++ b/lib/nats/io/rails.rb
@@ -1,0 +1,29 @@
+require "rails"
+
+module NATS
+  class Rails < ::Rails::Engine
+    # This class is used to free resources managed by Rails (e.g. database connections)
+    # that were implicitly acquired in subscription callbacks
+    # Implementation is based on https://github.com/sidekiq/sidekiq/blob/5e1a77a6d03193dd977fbfe8961ab78df91bb392/lib/sidekiq/rails.rb
+    class Reloader
+      def initialize(app = ::Rails.application)
+        @app = app
+      end
+
+      def call
+        params = (::Rails::VERSION::STRING >= "7.1") ? {source: "gem.nats"} : {}
+        @app.reloader.wrap(**params) do
+          yield
+        end
+      end
+
+      def inspect
+        "#<NATS::Rails::Reloader @app=#{@app.class.name}>"
+      end
+    end
+
+    config.after_initialize do
+      NATS::Client.default_reloader = NATS::Rails::Reloader.new
+    end
+  end
+end

--- a/lib/nats/io/subscription.rb
+++ b/lib/nats/io/subscription.rb
@@ -122,7 +122,7 @@ module NATS
       # Decrease pending size since consumed already
       synchronize { self.pending_size -= msg.data.size }
 
-      begin
+      nc.reloader.call do
         # Note: Keep some of the alternative arity versions to slightly
         # improve backwards compatibility.  Eventually fine to deprecate
         # since recommended version would be arity of 1 to get a NATS::Msg.

--- a/sig/nats/io/client.rbs
+++ b/sig/nats/io/client.rbs
@@ -25,6 +25,7 @@ module NATS
     attr_reader stats: Hash[Symbol, Integer]
     attr_reader uri: String?
     attr_reader subscription_executor: Concurrent::ThreadPoolExecutor?
+    attr_reader reloader: Proc
 
     DEFAULT_PORT: 4222
     DEFAULT_URI: String
@@ -99,6 +100,10 @@ module NATS
     @inbox_prefix: String
 
     @drain_t: Thread?
+
+    @reloader: Proc
+
+    def self.default_reloader: -> Proc
 
     def connect: ((String | Hash[Symbol, untyped])?, Hash[Symbol, untyped]) -> self
 

--- a/spec/client_threadsafe_spec.rb
+++ b/spec/client_threadsafe_spec.rb
@@ -204,6 +204,8 @@ describe 'Client - Thread safety' do
   major_version, minor_version, _ = Gem.loaded_specs['uri'].version.to_s.split('.').map(&:to_i)
   if major_version >= 0 && minor_version >= 11
     it 'should be able to process messages in a Ractor' do
+      pending "As of Rails 7.0 known to fail with errors about unshareable objects" if defined? Rails
+
       nc = NATS.connect(@s.uri)
 
       messages = []
@@ -221,6 +223,7 @@ describe 'Client - Thread safety' do
         'r1 Finished'
       end
       r1.take # wait for Ractor to finish sending messages
+      Thread.pass # allow subscription thread to process messages
       expect(messages.count).to eql(1)
 
       r2 = Ractor.new(@s.uri) do |uri|

--- a/spec/integration/rails_spec.rb
+++ b/spec/integration/rails_spec.rb
@@ -1,0 +1,60 @@
+require 'rails'
+require 'nats/io/rails'
+require 'rails/application'
+require 'active_record'
+require 'active_record/railtie'
+
+require 'spec_helper'
+
+describe 'Rails integration' do
+
+  before(:all) do
+    @serverctl = NatsServerControl.new.tap { |s| s.start_server(true) }
+  end
+
+  after(:all) do
+    @serverctl.kill_server
+  end
+
+  around(:each) do |example|
+    old_database_url = ENV["DATABASE_URL"]
+    ENV["DATABASE_URL"] ||= "sqlite3::memory:?db_pool_size=#{db_pool_size}&checkout_timeout=#{checkout_timeout}"
+    example.run
+  ensure
+    ENV["DATABASE_URL"] = old_database_url
+  end
+
+  let(:db_pool_size) { 5 }
+  let(:checkout_timeout) { 2 }
+
+  let!(:application) do
+    stub_const("TestApp", Class.new(Rails::Application) do
+      config.eager_load = true
+      config.active_record.legacy_connection_handling = false if config.active_record.respond_to?(:legacy_connection_handling)
+    end).tap { Rails.application.initialize!}
+  end
+
+  it 'should give back implicitly checked out database connections' do
+    nats = NATS.connect
+
+    queue = Queue.new
+    (db_pool_size * 2).times do |i|
+      nats.subscribe("ar-test") do |msg|
+        ActiveRecord::Base.connection.execute("SELECT 1") # Implicitly checkout connection
+        queue << i
+      end
+    end
+    nats.flush
+
+    nats.publish("ar-test", "hello")
+    nats.drain
+
+    # Wait for all subscriptions to be processed
+    finished = false
+    nats.on_close { finished = true }
+    sleep 0.1 until finished
+
+    expect { ActiveRecord::Base.connection.execute("SELECT 1") }.to_not raise_error
+    expect(queue.size).to eql(db_pool_size * 2)
+  end
+end


### PR DESCRIPTION
**The problem**:

 1. NATS subscription callbacks are executed in a different thread than code made a subscription
 2. ActiveRecord will implicitly checkout a new database connection from its connection pool for every thread that tries to execute a query (so every thread gives its own connection)
 3. When application wants to e.g. access database on subscription message received, this means that new different database connection will be checked out from the pool
 4. Implicitly checked out connections won't be automatically check in back to the pool (unless original thread is gone)
 5. It will result in database connection starvation: once pool won't have any connections, other threads (Puma or Sidekiq workers) will start waiting for a few last connections, reducing application performance and raising a lot of `ActiveRecord::ConnectionTimeoutError` exceptions.

**Solution**:
Automagically integrate with Ruby on Rails [Executor](https://guides.rubyonrails.org/threading_and_code_execution.html#executor) on rails apps to return back all resources, that were implicitly taken during subscription callback execution.

**Notes**:
 - Implementation relies on presence of `Rails::Engine` constant, that means that Ruby on Rails must be loaded first for this to work.
 - Implementation was heavily inspired by Sidekiq one. Sidekiq is using LGPLv3 while NATS-pure.rb is using Apache-2.0 license