### PR TITLE
Support connecting to NATS cluster over WebSocket

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ group :test do
   gem 'rails', require: false
   gem 'activerecord', require: false
   gem 'sqlite3', require: false
+  gem 'websocket'
 end
 
 group :v2 do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -163,6 +163,7 @@ GEM
     timeout (0.3.2)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
+    websocket (1.2.9)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -181,6 +182,7 @@ DEPENDENCIES
   rspec
   ruby-progressbar
   sqlite3
+  websocket
 
 BUNDLED WITH
    2.4.10

--- a/README.md
+++ b/README.md
@@ -143,6 +143,25 @@ loop do
 end
 ```
 
+## WebSocket
+
+Since NATS server 2.2 it is possible to connect to a NATS server [using WebSocket](https://docs.nats.io/running-a-nats-service/configuration/websocket), which is more secure then standard protocol if TLS is used and allows to traverse strict firewalls.
+
+ 1. Add a [`websocket`](https://github.com/imanel/websocket-ruby) gem to your Gemfile:
+
+    ```ruby
+    # Gemfile
+    gem 'websocket'
+    ```
+
+ 2. Connect to WebSocket-enabled NATS cluster using `ws` or `wss` protocol in URLs (for plain and secure connection respectively):
+
+    ```ruby
+    nats = NATS.connect("wss://demo.nats.io:8443")
+    ```
+
+ 3. Use NATS as usual.
+
 ## Ractor Usage
 
 Using NATS within a Ractor requires URI 0.11.0 or greater to be installed.

--- a/lib/nats/io/client.rb
+++ b/lib/nats/io/client.rb
@@ -103,8 +103,8 @@ module NATS
 
     attr_reader :status, :server_info, :server_pool, :options, :connected_server, :stats, :uri, :subscription_executor, :reloader
 
-    DEFAULT_PORT = 4222
-    DEFAULT_URI = ("nats://localhost:#{DEFAULT_PORT}".freeze)
+    DEFAULT_PORT = { nats: 4222, ws: 80, wss: 443 }.freeze
+    DEFAULT_URI = ("nats://localhost:#{DEFAULT_PORT[:nats]}".freeze)
 
     CR_LF = ("\r\n".freeze)
     CR_LF_SIZE = (CR_LF.bytesize)
@@ -294,12 +294,8 @@ module NATS
       when String
         # Initialize TLS defaults in case any url is using it.
         srvs = opts[:servers] = process_uri(uri)
-        if srvs.any? {|u| u.scheme == 'tls'} and !opts[:tls]
-          tls_context = OpenSSL::SSL::SSLContext.new
-          tls_context.set_params
-          opts[:tls] = {
-            context: tls_context
-          }
+        if srvs.any? {|u| %w[tls wss].include? u.scheme } and !opts[:tls]
+          opts[:tls] = { context: tls_context }
         end
         @single_url_connect_used = true if srvs.size == 1
       when Hash
@@ -380,6 +376,14 @@ module NATS
       begin
         srv = select_next_server
 
+        # Use the hostname from the server for TLS hostname verification.
+        if client_using_secure_connection? and single_url_connect_used?
+          # Always reuse the original hostname used to connect.
+          @hostname ||= srv[:hostname]
+        else
+          @hostname = srv[:hostname]
+        end
+
         # Create TCP socket connection to NATS
         @io = create_socket
         @io.connect
@@ -390,14 +394,6 @@ module NATS
 
         # Connection established and now in process of sending CONNECT to NATS
         @status = CONNECTING
-
-        # Use the hostname from the server for TLS hostname verification.
-        if client_using_secure_connection? and single_url_connect_used?
-          # Always reuse the original hostname used to connect.
-          @hostname ||= srv[:hostname]
-        else
-          @hostname = srv[:hostname]
-        end
 
         # Established TCP connection successfully so can start connect
         process_connect_init
@@ -1071,6 +1067,23 @@ module NATS
       @uri.scheme == "tls" || @tls
     end
 
+    def tls_context
+      return nil unless @tls
+
+      # Allow prepared context and customizations via :tls opts
+      return @tls[:context] if @tls[:context]
+
+      @tls_context ||= OpenSSL::SSL::SSLContext.new.tap do |tls_context|
+        # Use the default verification options from Ruby:
+        # https://github.com/ruby/ruby/blob/96db72ce38b27799dd8e80ca00696e41234db6ba/ext/openssl/lib/openssl/ssl.rb#L19-L29
+        #
+        # Insecure TLS versions not supported already:
+        # https://github.com/ruby/openssl/commit/3e5a009966bd7f806f7180d82cf830a04be28986
+        #
+        tls_context.set_params
+      end
+    end
+
     def single_url_connect_used?
       @single_url_connect_used
     end
@@ -1407,39 +1420,12 @@ module NATS
 
       case
       when (server_using_secure_connection? and client_using_secure_connection?)
-        tls_context = nil
-
-        if @tls
-          # Allow prepared context and customizations via :tls opts
-          tls_context = @tls[:context] if @tls[:context]
-        else
-          # Defaults
-          tls_context = OpenSSL::SSL::SSLContext.new
-
-          # Use the default verification options from Ruby:
-          # https://github.com/ruby/ruby/blob/96db72ce38b27799dd8e80ca00696e41234db6ba/ext/openssl/lib/openssl/ssl.rb#L19-L29
-          #
-          # Insecure TLS versions not supported already:
-          # https://github.com/ruby/openssl/commit/3e5a009966bd7f806f7180d82cf830a04be28986
-          #
-          tls_context.set_params
-        end
-
-        # Setup TLS connection by rewrapping the socket
-        tls_socket = OpenSSL::SSL::SSLSocket.new(@io.socket, tls_context)
-
-        # Close TCP socket after closing TLS socket as well.
-        tls_socket.sync_close = true
-
-        # Required to enable hostname verification if Ruby runtime supports it (>= 2.4):
-        # https://github.com/ruby/openssl/commit/028e495734e9e6aa5dba1a2e130b08f66cf31a21
-        tls_socket.hostname = @hostname
-
-        tls_socket.connect
-        @io.socket = tls_socket
+        @io.setup_tls!
       when (server_using_secure_connection? and !client_using_secure_connection?)
         raise NATS::IO::ConnectError.new('TLS/SSL required by server')
-      when (client_using_secure_connection? and !server_using_secure_connection?)
+      # Server requiring TLS/SSL over websocket but not requiring it over standard protocol
+      # doesn't send `tls_required` in its INFO so we need to check the URI scheme.
+      when (client_using_secure_connection? and !server_using_secure_connection? and @uri.scheme != "wss")
         raise NATS::IO::ConnectError.new('TLS/SSL not supported by server')
       else
         # Otherwise, use a regular connection.
@@ -1484,11 +1470,6 @@ module NATS
       begin
         srv = select_next_server
 
-        # Establish TCP connection with new server
-        @io = create_socket
-        @io.connect
-        @stats[:reconnects] += 1
-
         # Set hostname to use for TLS hostname verification
         if client_using_secure_connection? and single_url_connect_used?
           # Reuse original hostname name in case of using TLS.
@@ -1496,6 +1477,11 @@ module NATS
         else
           @hostname = srv[:hostname]
         end
+
+        # Establish TCP connection with new server
+        @io = create_socket
+        @io.connect
+        @stats[:reconnects] += 1
 
         # Established TCP connection successfully so can start connect
         process_connect_init
@@ -1712,10 +1698,21 @@ module NATS
     end
 
     def create_socket
-      NATS::IO::Socket.new({
-          uri: @uri,
-          connect_timeout: NATS::IO::DEFAULT_CONNECT_TIMEOUT
-        })
+      socket_class = case @uri.scheme
+        when "nats", "tls"
+          NATS::IO::Socket
+        when "ws", "wss"
+          require_relative 'websocket'
+          NATS::IO::WebSocket
+        else
+          raise NotImplementedError, "#{@uri.scheme} protocol is not supported, check NATS cluster URL spelling"
+        end
+
+      socket_class.new(
+        uri: @uri,
+        tls: { context: tls_context, hostname: @hostname },
+        connect_timeout: NATS::IO::DEFAULT_CONNECT_TIMEOUT,
+      )
     end
 
     def setup_nkeys_connect
@@ -1825,7 +1822,7 @@ module NATS
 
         # Host and Port
         uri_object.hostname ||= "localhost"
-        uri_object.port ||= DEFAULT_PORT
+        uri_object.port ||= DEFAULT_PORT.fetch(uri.scheme.to_sym, DEFAULT_PORT[:nats])
 
         uri_object
       end
@@ -1877,6 +1874,7 @@ module NATS
         @write_timeout = options[:write_timeout]
         @read_timeout = options[:read_timeout]
         @socket = nil
+        @tls = options[:tls]
       end
 
       def connect
@@ -1893,6 +1891,22 @@ module NATS
 
         # Set TCP no delay by default
         @socket.setsockopt(::Socket::IPPROTO_TCP, ::Socket::TCP_NODELAY, 1)
+      end
+
+      # (Re-)connect using secure connection if server and client agreed on using it.
+      def setup_tls!
+        # Setup TLS connection by rewrapping the socket
+        tls_socket = OpenSSL::SSL::SSLSocket.new(@socket, @tls.fetch(:context))
+
+        # Close TCP socket after closing TLS socket as well.
+        tls_socket.sync_close = true
+
+        # Required to enable hostname verification if Ruby runtime supports it (>= 2.4):
+        # https://github.com/ruby/openssl/commit/028e495734e9e6aa5dba1a2e130b08f66cf31a21
+        tls_socket.hostname = @tls[:hostname]
+
+        tls_socket.connect
+        @socket = tls_socket
       end
 
       def read_line(deadline=nil)

--- a/lib/nats/io/websocket.rb
+++ b/lib/nats/io/websocket.rb
@@ -1,0 +1,76 @@
+begin
+  require 'websocket'
+rescue LoadError
+  raise LoadError, "Please add `websocket` gem to your Gemfile to connect to NATS via WebSocket."
+end
+
+module NATS
+  module IO
+    # WebSocket to connect to NATS via WebSocket and automatically decode and encode frames.
+
+    # @see https://docs.nats.io/running-a-nats-service/configuration/websocket
+
+    class WebSocket < Socket
+      class HandshakeError < RuntimeError; end
+
+      attr_accessor :socket
+
+      def initialize(options={})
+        super
+      end
+
+      def connect
+
+        super
+
+        setup_tls! if @uri.scheme == "wss" # WebSocket connection must be made over TLS from the beginning
+
+        @handshake = ::WebSocket::Handshake::Client.new url: @uri.to_s
+        @frame = ::WebSocket::Frame::Incoming::Client.new
+        @handshaked = false
+
+        @socket.write @handshake.to_s
+
+        until @handshaked
+          @handshake << method(:read).super_method.call(MAX_SOCKET_READ_BYTES)
+          if @handshake.finished?
+            @handshaked = true
+          end
+        end
+      end
+
+      def setup_tls!
+        return if @socket.is_a? OpenSSL::SSL::SSLSocket
+
+        super
+      end
+
+      def read(max_bytes=MAX_SOCKET_READ_BYTES, deadline=nil)
+        data = super
+        @frame << data
+        result = []
+        while msg = @frame.next
+          result << msg
+        end
+        result.join
+      end
+
+      def read_line(deadline=nil)
+        data = super
+        @frame << data
+        result = []
+        while msg = @frame.next
+          result << msg
+        end
+        result.join
+      end
+
+      def write(data, deadline=nil)
+        raise HandshakeError, "Attempted to write to socket while WebSocket handshake is in progress" unless @handshaked
+
+        frame = ::WebSocket::Frame::Outgoing::Client.new(data: data, type: :binary, version: @handshake.version)
+        super frame.to_s
+      end
+    end
+  end
+end

--- a/sig/nats/io/client.rbs
+++ b/sig/nats/io/client.rbs
@@ -27,7 +27,7 @@ module NATS
     attr_reader subscription_executor: Concurrent::ThreadPoolExecutor?
     attr_reader reloader: Proc
 
-    DEFAULT_PORT: 4222
+    DEFAULT_PORT: Hash[Symbol, Integer]
     DEFAULT_URI: String
 
     CR_LF: '\r\n'

--- a/spec/client_ws_spec.rb
+++ b/spec/client_ws_spec.rb
@@ -1,0 +1,104 @@
+# Copyright 2016-2018 The NATS Authors
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+require 'openssl'
+require 'erb'
+
+describe 'Client - WebSocket spec' do
+  before :each do
+    @natsctl = NatsServerControl.init_with_config_from_string(config.result(binding), opts)
+    @natsctl.start_server(true)
+  end
+
+  after :each do
+    @natsctl.kill_server
+  end
+
+  context 'when server accepts websocket connections without TLS' do
+    let :opts do
+      {
+        'pid_file' => '/tmp/test-nats-8080.pid',
+        'host' => '127.0.0.1',
+        'port' => 4080,
+        'wsport' => 8080,
+      }
+    end
+    let :config do
+      ERB.new(<<~CONF)
+        net:  "<%= opts['host'] %>"
+        port: <%= opts['port'] %>
+        websocket {
+          port: <%= opts['wsport'] %>
+          no_tls: true
+        }
+      CONF
+    end
+
+    it 'should work' do
+      nats = NATS.connect("ws://localhost:8080")
+
+      nats.subscribe("hello") do |msg, reply|
+        nats.publish(reply, 'ok')
+      end
+
+      response = nats.request("hello", "world")
+      expect(response.data).to eql("ok")
+    end
+  end
+
+  context 'when server requires TLS for websocket connections' do
+    let :opts do
+      {
+        'pid_file' => '/tmp/test-nats-8443.pid',
+        'host' => '127.0.0.1',
+        'port' => 4443,
+        'wsport' => 8443,
+      }
+    end
+    let :config do
+      ERB.new(<<~CONF)
+        net:  "<%= opts['host'] %>"
+        port: <%= opts['port'] %>
+        websocket {
+          port: <%= opts['wsport'] %>
+          tls {
+            cert_file:  "./spec/configs/certs/server.pem"
+            key_file:   "./spec/configs/certs/key.pem"
+          }
+        }
+      CONF
+    end
+
+    it 'should connect over TLS' do
+      tls_context = OpenSSL::SSL::SSLContext.new
+      tls_context.set_params
+      tls_context.ca_file = "./spec/configs/certs/ca.pem"
+      nats = NATS.connect(
+         servers: ['wss://localhost:8443'],
+         reconnect: false,
+         tls: {
+           context: tls_context
+         }
+      )
+
+      nats.subscribe("hello") do |msg, reply|
+        nats.publish(reply, 'ok')
+      end
+
+      response = nats.request("hello", "world")
+      expect(response.data).to eql("ok")
+    end
+  end
+end


### PR DESCRIPTION
See https://docs.nats.io/running-a-nats-service/configuration/websocket

- [x] Support websocket connection
- [x] TLS support
- [x] Refactoring
- [x] specs for both non-TLS and TLS