### PR TITLE
Include LICENSE and README into built gem package

### DIFF
--- a/nats-pure.gemspec
+++ b/nats-pure.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir['lib/**/*.rb']
   s.files += Dir['sig/**/*.rbs']
+  s.files += %w[LICENSE README.md]
 
   s.add_dependency "concurrent-ruby", "~> 1.0"
 end


### PR DESCRIPTION
Today I noticed that only lib/ and sig/ folders are packaged into .gem file on release. However, RubyGems gem specification reference [guides](https://guides.rubygems.org/specification-reference/#license=) that full license test should be placed into the built gem (emphasis is mine):

> This should just be the name of your license. **The full text of the license should be inside of the gem (at the top level) when you build it.**

Also added the README file for unfortunate (but unlikely) case if someone will be forced to work with the gem without Internet access (e.g. debugging an application deployed in isolated internal enterprise network).