### PR TITLE
Fix loading Rails Engine

### DIFF
--- a/lib/nats/client.rb
+++ b/lib/nats/client.rb
@@ -12,4 +12,5 @@
 # limitations under the License.
 #
 require 'nats/io/client'
+require 'nats/io/rails' if defined?(Rails::Engine)
 require 'nats/nuid'

--- a/lib/nats/io/client.rb
+++ b/lib/nats/io/client.rb
@@ -18,7 +18,6 @@ require_relative 'errors'
 require_relative 'msg'
 require_relative 'subscription'
 require_relative 'jetstream'
-require_relative "rails" if defined?(::Rails::Engine)
 
 require 'nats/nuid'
 require 'thread'


### PR DESCRIPTION
Currently, if we require `nats-pure` after the application has been initialized, the `after_initilize` hook fails since `Client` hasn't been defined yet: https://github.com/nats-io/nats-pure.rb/blob/0ab892cc6af9d1a2b1e6a30567f94a0daaf77ad7/lib/nats/io/rails.rb#L25-L26

Example exception (see [build](https://github.com/anycable/anycable-go/actions/runs/6146040705/job/16698478321?pr=189)):

```sh
NameError: uninitialized constant NATS::Client
[1259](https://github.com/anycable/anycable-go/actions/runs/6146040705/job/16698478321?pr=189#step:11:1260)
            /home/runner/work/anycable-go/anycable-go/vendor/bundle/ruby/2.7.0/gems/nats-pure-2.3.0/lib/nats/io/rails.rb:26:in `block in <class:Rails>'
[1260](https://github.com/anycable/anycable-go/actions/runs/6146040705/job/16698478321?pr=189#step:11:1261)
            /home/runner/work/anycable-go/anycable-go/vendor/bundle/ruby/2.7.0/gems/activesupport-7.0.8/lib/active_support/lazy_load_hooks.rb:92:in `block in execute_hook'
[1261](https://github.com/anycable/anycable-go/actions/runs/6146040705/job/16698478321?pr=189#step:11:1262)
            /home/runner/work/anycable-go/anycable-go/vendor/bundle/ruby/2.7.0/gems/activesupport-7.0.8/lib/active_support/lazy_load_hooks.rb:85:in `with_execution_control'
[1262](https://github.com/anycable/anycable-go/actions/runs/6146040705/job/16698478321?pr=189#step:11:1263)
            /home/runner/work/anycable-go/anycable-go/vendor/bundle/ruby/2.7.0/gems/activesupport-7.0.8/lib/active_support/lazy_load_hooks.rb:90:in `execute_hook'
[1263](https://github.com/anycable/anycable-go/actions/runs/6146040705/job/16698478321?pr=189#step:11:1264)
            /home/runner/work/anycable-go/anycable-go/vendor/bundle/ruby/2.7.0/gems/activesupport-7.0.8/lib/active_support/lazy_load_hooks.rb:60:in `block in on_load'
[1264](https://github.com/anycable/anycable-go/actions/runs/6146040705/job/16698478321?pr=189#step:11:1265)
            /home/runner/work/anycable-go/anycable-go/vendor/bundle/ruby/2.7.0/gems/activesupport-7.0.8/lib/active_support/lazy_load_hooks.rb:59:in `each'
```

We should load Rails extensions only after all the _core_ functionality has been loaded. So, I moved loading `rails.rb` to `client.rb`. 


