### PR TITLE
Fix crash when assigning URI port to default value

### DIFF
--- a/lib/nats/io/client.rb
+++ b/lib/nats/io/client.rb
@@ -1824,7 +1824,7 @@ module NATS
 
         # Host and Port
         uri_object.hostname ||= "localhost"
-        uri_object.port ||= DEFAULT_PORT.fetch(uri.scheme.to_sym, DEFAULT_PORT[:nats])
+        uri_object.port ||= DEFAULT_PORT.fetch(uri_object.scheme.to_sym, DEFAULT_PORT[:nats])
 
         uri_object
       end


### PR DESCRIPTION
After the changes implemented in #127, connecting to a URI without an explicit port in it (e.g. `demo.nats.io`) caused a crash:

```
irb(main):004:0> NATS.connect("demo.nats.io")
/usr/local/bundle/gems/nats-pure-2.3.0/lib/nats/io/client.rb:1828:in `block in process_uri': undefined method `scheme' for "nats://demo.nats.io":String (NoMethodError)
        from /usr/local/bundle/gems/nats-pure-2.3.0/lib/nats/io/client.rb:1818:in `map'
        from /usr/local/bundle/gems/nats-pure-2.3.0/lib/nats/io/client.rb:1818:in `process_uri'
        from /usr/local/bundle/gems/nats-pure-2.3.0/lib/nats/io/client.rb:296:in `parse_and_validate_options'
        from /usr/local/bundle/gems/nats-pure-2.3.0/lib/nats/io/client.rb:265:in `connect'
        from /usr/local/bundle/gems/nats-pure-2.3.0/lib/nats/io/client.rb:52:in `connect'
        from (irb):4:in `<main>'
        from bin/console:7:in `<main>'
```

This PR fixes that bug.