### PR TITLE
Add support for consumer multiple filters and streams/consumers metadata

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,14 +28,14 @@ jobs:
   include:
   - name: "Ruby: 3.3.0"
     rvm: "3.3.0-preview1"
-  - name: "Ruby: 3.2.0 (nats-server@dev)"
+  - name: "Ruby: 3.2.0 (nats-server@v2.9)"
     rvm: "3.2.0"
     env:
-    - NATS_SERVER_VERSION=dev
+    - NATS_SERVER_VERSION=v2.9.24
   - name: "Ruby: 3.2.0 (nats-server@main)"
     rvm: "3.2.0"
     env:
     - NATS_SERVER_VERSION=main
   allow_failures:
     - name: "Ruby: 3.3.0"
-    - name: "Ruby: 3.2.0 (nats-server@dev)"
+    - name: "Ruby: 3.2.0 (nats-server@main)"

--- a/Gemfile
+++ b/Gemfile
@@ -6,9 +6,6 @@ group :test do
   gem 'rake'
   gem 'rspec'
   gem 'benchmark-ips'
-  gem 'rails', require: false
-  gem 'activerecord', require: false
-  gem 'sqlite3', require: false
   gem 'websocket'
 end
 
@@ -18,4 +15,10 @@ end
 
 group :development do
   gem 'ruby-progressbar'
+end
+
+group :rails do
+  gem 'rails', require: false
+  gem 'activerecord', require: false
+  gem 'sqlite3', require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    nats-pure (2.3.1)
+    nats-pure (2.4.0)
       concurrent-ruby (~> 1.0)
 
 GEM

--- a/lib/nats/io/jetstream/api.rb
+++ b/lib/nats/io/jetstream/api.rb
@@ -195,6 +195,7 @@ module NATS
         :republish,
         :allow_direct,
         :mirror_direct,
+        :metadata,
         keyword_init: true) do
         def initialize(opts={})
           # Filter unrecognized fields just in case.

--- a/lib/nats/io/jetstream/api.rb
+++ b/lib/nats/io/jetstream/api.rb
@@ -119,6 +119,9 @@ module NATS
                                   :num_replicas,
                                   # Force memory storage
                                   :mem_storage,
+
+                                  # NATS v2.10 features
+                                  :metadata, :filter_subjects, :max_bytes,
                                   keyword_init: true) do
         def initialize(opts={})
           # Filter unrecognized fields just in case.

--- a/lib/nats/io/jetstream/manager.rb
+++ b/lib/nats/io/jetstream/manager.rb
@@ -106,18 +106,37 @@ module NATS
                  else
                    config
                  end
-
+        config[:name] ||= config[:durable_name]
         req_subject = case
                       when config[:name]
-                        # NOTE: Only supported after nats-server v2.9.0
+                        ###############################################################################
+                        #                                                                             #
+                        #  Using names is the supported way of creating consumers (NATS +v2.9.0.      #
+                        #                                                                             #
+                        ###############################################################################
                         if config[:filter_subject] && config[:filter_subject] != ">"
                           "#{@prefix}.CONSUMER.CREATE.#{stream}.#{config[:name]}.#{config[:filter_subject]}"
                         else
+                         ##############################################################################
+                         #                                                                            #
+                         # Endpoint to support creating ANY consumer with multi-filters (NATS +v2.10) #
+                         #                                                                            #
+                         ##############################################################################
                           "#{@prefix}.CONSUMER.CREATE.#{stream}.#{config[:name]}"
                         end
                       when config[:durable_name]
+                        ###############################################################################
+                        #                                                                             #
+                        # Endpoint to support creating DURABLES before NATS v2.9.0.                   #
+                        #                                                                             #
+                        ###############################################################################
                         "#{@prefix}.CONSUMER.DURABLE.CREATE.#{stream}.#{config[:durable_name]}"
                       else
+                        ###############################################################################
+                        #                                                                             #
+                        # Endpoint to support creating EPHEMERALS before NATS v2.9.0.                 #
+                        #                                                                             #
+                        ###############################################################################
                         "#{@prefix}.CONSUMER.CREATE.#{stream}"
                       end
 

--- a/lib/nats/io/version.rb
+++ b/lib/nats/io/version.rb
@@ -15,7 +15,7 @@
 module NATS
   module IO
     # VERSION is the version of the client announced on CONNECT to the server.
-    VERSION = "2.3.1".freeze
+    VERSION = "2.4.0".freeze
 
     # LANG is the lang runtime of the client announced on CONNECT to the server.
     LANG = "#{RUBY_ENGINE}#{RUBY_VERSION}".freeze

--- a/spec/integration/rails_spec.rb
+++ b/spec/integration/rails_spec.rb
@@ -1,19 +1,23 @@
-require 'rails'
-require 'nats/io/rails'
-require 'rails/application'
-require 'active_record'
-require 'active_record/railtie'
+
+begin
+  require 'rails'
+  require 'nats/io/rails'
+  require 'rails/application'
+  require 'active_record'
+  require 'active_record/railtie'
+rescue LoadError
+end
 
 require 'spec_helper'
 
 describe 'Rails integration' do
-
   before(:all) do
+    skip 'rails not installed' if not defined?(Rails)
     @serverctl = NatsServerControl.new.tap { |s| s.start_server(true) }
   end
 
   after(:all) do
-    @serverctl.kill_server
+    @serverctl.kill_server if @serverctl
   end
 
   around(:each) do |example|

--- a/spec/js_features_spec.rb
+++ b/spec/js_features_spec.rb
@@ -31,6 +31,8 @@ describe 'JetStream' do
 
     it 'should create pull subscribers with multiple filter subjects' do
       nc = NATS.connect(@s.uri)
+      skip 'requires v2.10' unless ENV['NATS_SERVER_VERSION'] == "main"
+
       js = nc.jetstream
       js.add_stream(name: "MULTI_FILTER", subjects: ["foo.one.*", "foo.two.*", "foo.three.*"])
       js.add_stream(name: "ANOTHER_MULTI_FILTER", subjects: ["foo.five.*"])

--- a/spec/js_features_spec.rb
+++ b/spec/js_features_spec.rb
@@ -1,0 +1,164 @@
+# Copyright 2016-2023 The NATS Authors
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'spec_helper'
+require 'monitor'
+require 'tmpdir'
+
+describe 'JetStream' do
+  describe 'NATS v2.10 Features' do
+    before(:each) do
+      @tmpdir = Dir.mktmpdir("ruby-jetstream")
+      @s = NatsServerControl.new("nats://127.0.0.1:4852", "/tmp/test-nats.pid", "-js -sd=#{@tmpdir}")
+      @s.start_server(true)
+    end
+
+    after(:each) do
+      @s.kill_server
+      FileUtils.remove_entry(@tmpdir)
+    end
+
+    it 'should create pull subscribers with multiple filter subjects' do
+      nc = NATS.connect(@s.uri)
+      js = nc.jetstream
+      js.add_stream(name: "MULTI_FILTER", subjects: ["foo.one.*", "foo.two.*", "foo.three.*"])
+      js.add_stream(name: "ANOTHER_MULTI_FILTER", subjects: ["foo.five.*"])
+
+      js.publish("foo.one.1", "1")
+      js.publish("foo.two.2", "2")
+      js.publish("foo.three.3", "3")
+      js.publish("foo.two.2", "22")
+      js.publish("foo.one.3", "11")
+
+      # Manually using add_consumer JS API to create an ephemeral.
+      expect do
+        consumer = js.add_consumer("MULTI_FILTER", {
+          name: "my-ephemeral",
+          filter_subjects: ["foo.one.*", "foo.two.*"]
+        })
+        # For ephemerals, have to use nil for both subject and durable options
+        sub = js.pull_subscribe(nil, nil, name: "my-ephemeral", stream: "MULTI_FILTER")
+        msgs = sub.fetch(5)
+        msgs.each do |msg|
+          msg.ack
+        end
+        expect(msgs.count).to eql(4)
+        expect(msgs[0].subject).to eql('foo.one.1')
+        expect(msgs[1].subject).to eql('foo.two.2')
+        expect(msgs[2].subject).to eql('foo.two.2')
+        expect(msgs[3].subject).to eql('foo.one.3')
+      end.to_not raise_error
+
+      # Manually using add_consumer JS API to create a durable.
+      expect do
+        consumer = js.add_consumer("MULTI_FILTER", {
+          durable_name: "my-durable",
+          filter_subjects: ["foo.three.*"]
+        })
+        # To bind without creating have to use nil for both subject and durable options.
+        sub = js.pull_subscribe(nil, nil, name: "my-durable", stream: "MULTI_FILTER")
+        msgs = sub.fetch(5)
+        msgs.each do |msg|
+          msg.ack
+        end
+        expect(msgs.count).to eql(1)
+        expect(msgs[0].subject).to eql('foo.three.3')
+      end.to_not raise_error
+
+      # Binding to stream explicitly.
+      expect do
+        sub = js.pull_subscribe(["foo.one.1", "foo.two.2"], "MULTI_FILTER_CONSUMER", stream: "MULTI_FILTER")
+        info = sub.consumer_info
+        expect(info.name).to eql('MULTI_FILTER_CONSUMER')
+        expect(info.config.durable_name).to eql('MULTI_FILTER_CONSUMER')
+        expect(info.config.max_waiting).to eql(512)
+        expect(info.num_pending).to eql(3)
+
+        msgs = sub.fetch(5)
+        msgs.each do |msg|
+          msg.ack
+        end
+        expect(msgs.count).to eql(3)
+        expect(msgs[0].subject).to eql('foo.one.1')
+        expect(msgs[1].subject).to eql('foo.two.2')
+        expect(msgs[2].subject).to eql('foo.two.2')
+        expect(msgs[2].data).to eql('22')
+      end.to_not raise_error
+
+      # Creating a single filter consumer using an Array.
+      expect do
+        config = NATS::JetStream::API::ConsumerConfig.new(max_waiting: 128)
+        sub = js.pull_subscribe(["foo.one.1"], "psub2", config: config)
+        info = sub.consumer_info
+        expect(info.config.max_waiting).to eql(128)
+        expect(info.num_pending).to eql(1)
+
+        msgs = sub.fetch(5)
+        msgs.each do |msg|
+          msg.ack
+        end
+        expect(msgs[0].subject).to eql('foo.one.1')
+        expect(msgs.count).to eql(1)
+      end.to_not raise_error
+
+      # Auto creating a consumer via a loookup.
+      expect do
+        sub = js.pull_subscribe(["foo.one.1", "foo.two.2"], "psub3")
+        info = sub.consumer_info
+        expect(info.num_pending).to eql(3)
+
+        msgs = sub.fetch(5)
+        msgs.each do |msg|
+          msg.ack
+        end
+        expect(msgs[0].subject).to eql('foo.one.1')
+        expect(msgs[1].subject).to eql('foo.two.2')
+        expect(msgs[2].subject).to eql('foo.two.2')
+        expect(msgs.count).to eql(3)
+      end.to_not raise_error
+
+      # Auto creating a consumer with stream that does not match.
+      expect do
+        sub = js.pull_subscribe(["foo.one.1", "foo.four.4"], "psub4")
+        info = sub.consumer_info
+        expect(info.num_pending).to eql(3)
+
+        msgs = sub.fetch(5)
+        msgs.each do |msg|
+          msg.ack
+        end
+        expect(msgs[0].subject).to eql('foo.one.1')
+        expect(msgs[1].subject).to eql('foo.two.2')
+        expect(msgs[2].subject).to eql('foo.two.2')
+        expect(msgs.count).to eql(3)
+      end.to raise_error(NATS::JetStream::Error)
+
+      # Auto creating a consumer with stream that is ambiguous.
+      expect do
+        sub = js.pull_subscribe(["foo.one.1", "foo.one.2", "foo.five.4"], "psub5")
+        info = sub.consumer_info
+        expect(info.num_pending).to eql(3)
+
+        msgs = sub.fetch(5)
+        msgs.each do |msg|
+          msg.ack
+        end
+        expect(msgs[0].subject).to eql('foo.one.1')
+        expect(msgs[1].subject).to eql('foo.two.2')
+        expect(msgs[2].subject).to eql('foo.two.2')
+        expect(msgs.count).to eql(3)
+      end.to raise_error(NATS::JetStream::Error)
+    end
+  end
+end

--- a/spec/js_spec.rb
+++ b/spec/js_spec.rb
@@ -120,7 +120,7 @@ describe 'JetStream' do
       sub = js.pull_subscribe("hello", "psub", config: { max_waiting: 30 })
       info = sub.consumer_info
       expect(info.config.max_waiting).to eql(30)
-      expect(info.num_pending).to eql(3)
+      expect(info.num_pending).to eql(1)
 
       msgs = sub.fetch(3)
       msgs.each do |msg|
@@ -133,14 +133,14 @@ describe 'JetStream' do
       sub = js.pull_subscribe("hello", "psub2", config: config)
       info = sub.consumer_info
       expect(info.config.max_waiting).to eql(128)
-      expect(info.num_pending).to eql(3)
+      expect(info.num_pending).to eql(1)
 
       msgs = sub.fetch(1)
       msgs.each do |msg|
         msg.ack_sync
       end
       info = sub.consumer_info
-      expect(info.num_pending).to eql(2)
+      expect(info.num_pending).to eql(0)
     end
 
     it 'should find the pull subscription by subject' do


### PR DESCRIPTION

Examples:

```ruby
# Creating a stream with multiple subjects
js.add_stream(name: "MULTI_FILTER", subjects: ["foo.one.*", "foo.two.*", "foo.three.*"])

# PullSubscriber that takes an array and creates a consumer with multiple filters .
js.pull_subscribe(["foo.one.1", "foo.two.2"], "example")

# PushSubscriber that takes an array and creates a consumer with multiple filters .
js.subscribe(["foo.one.1", "foo.three.3"])

# via JetStream#add_consumer API
consumer = js.add_consumer("MULTI_FILTER", {
       name: "my-consumer",
       filter_subjects: ["foo.one.*", "foo.two.*"]
})

# Pass nil to both subject and durable consumer name to bind to already created consumer
js.pull_subscribe(nil, nil, name: "my-consumer", stream: "MULTI_FILTER")

# Stream with metadata
stream = js.add_stream({
    :name     => "WITH_METADATA",
    :metadata => {
      'foo': 'bar',
      'hello': 'world'
    }
})
```