### PR TITLE
Cast the timeout when fetching from JetStream

### DIFF
--- a/lib/nats/io/jetstream/pull_subscription.rb
+++ b/lib/nats/io/jetstream/pull_subscription.rb
@@ -55,7 +55,7 @@ module NATS
         end
 
         t = MonotonicTime.now
-        timeout = params[:timeout] ||= 5
+        timeout = params[:timeout] ? Float(params[:timeout]) : 5.0
         expires = (timeout * 1_000_000_000) - 100_000
         next_req = {
           batch: batch


### PR DESCRIPTION
We control our timeout via environment variables (worse – YAML) and had a silly bug in our code where the timeout was sent as a string. We kept running out of memory because the expires line was copying our string ("5") one billion times. D'oh!

This is just a simple fix to save new users like us some hassle.

I did run the js_spec.rb with this change, but I wasn't sure the preferred way (if any) of adding a test like this.

For others, this is what I did for a local Docker development setup:

```sh
# I added the base64 gem to the gemspec. I'm using Ruby 3.4-rc because concurrent ruby segfaults in 3.3.0.
% docker run -it -v $(pwd):/opt/app ruby:3.4-rc bash 
% bash ./scripts/install_nats.sh
% export PATH=$HOME/nats-server:$PATH
% nats-server &
% bundle install
% bundle exec rspec spec/js_spec.rb
```