### PR TITLE
Add uri gem as test dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ group :test do
   gem 'rake'
   gem 'rspec'
   gem 'benchmark-ips'
+  gem 'uri'
   gem 'websocket'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -164,6 +164,7 @@ GEM
     timeout (0.4.1)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
+    uri (0.13.0)
     websocket (1.2.9)
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
@@ -183,6 +184,7 @@ DEPENDENCIES
   rspec
   ruby-progressbar
   sqlite3
+  uri
   websocket
 
 BUNDLED WITH


### PR DESCRIPTION
`uri` is missing as a gem dependency.

Fixes: (tested on ruby 3.3)
```
An error occurred while loading ./spec/client_threadsafe_spec.rb. Failure/Error: major_version, minor_version, _ = Gem.loaded_specs['uri'].version.to_s.split('.').map(&:to_i)

NoMethodError:
  undefined method `version' for nil
```
