### PR TITLE
Fix various Ruby warnings

### DIFF
--- a/lib/nats/io/client.rb
+++ b/lib/nats/io/client.rb
@@ -100,7 +100,7 @@ module NATS
     include MonitorMixin
     include Status
 
-    attr_reader :status, :server_info, :server_pool, :options, :connected_server, :stats, :uri, :subscription_executor, :reloader
+    attr_reader :status, :server_info, :server_pool, :options, :stats, :uri, :subscription_executor, :reloader
 
     DEFAULT_PORT = { nats: 4222, ws: 80, wss: 443 }.freeze
     DEFAULT_URI = ("nats://localhost:#{DEFAULT_PORT[:nats]}".freeze)
@@ -620,7 +620,6 @@ module NATS
       end
       msg.reply = inbox
       msg.data ||= ''
-      msg_size = msg.data.bytesize
 
       # Publish request and wait for reply.
       publish_msg(msg)
@@ -930,8 +929,7 @@ module NATS
             key, value = line.strip.split(/\s*:\s*/, 2)
             hdr[key] = value
           end
-        rescue => e
-          err = e
+        rescue
         end
       end
 
@@ -1178,7 +1176,7 @@ module NATS
 
         # Wait until only the resp mux is remaining or there are no subscriptions.
         if @subs.count == 1
-          sid, sub = @subs.first
+          _sid, sub = @subs.first
           if sub == @resp_sub
             break
           end
@@ -1815,8 +1813,6 @@ module NATS
 
     def process_uri(uris)
       uris.split(',').map do |uri|
-        opts = {}
-
         # Scheme
         uri = "nats://#{uri}" if !uri.include?("://")
 

--- a/lib/nats/io/jetstream.rb
+++ b/lib/nats/io/jetstream.rb
@@ -12,7 +12,6 @@
 # limitations under the License.
 #
 require_relative 'msg'
-require_relative 'client'
 require_relative 'errors'
 require_relative 'kv'
 require_relative 'jetstream/api'

--- a/lib/nats/io/msg.rb
+++ b/lib/nats/io/msg.rb
@@ -11,7 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-require_relative 'jetstream'
+require_relative 'jetstream/msg'
 
 module NATS
   class Msg

--- a/lib/nats/io/subscription.rb
+++ b/lib/nats/io/subscription.rb
@@ -28,7 +28,8 @@ module NATS
     include MonitorMixin
 
     attr_accessor :subject, :queue, :future, :callback, :response, :received, :max, :pending, :sid
-    attr_accessor :pending_queue, :pending_size, :wait_for_msgs_cond, :concurrency_semaphore
+    attr_accessor :pending_queue, :pending_size, :wait_for_msgs_cond
+    attr_writer   :concurrency_semaphore
     attr_accessor :pending_msgs_limit, :pending_bytes_limit
     attr_accessor :nc
     attr_accessor :jsi


### PR DESCRIPTION
This PR fixes a bunch of ruby warnings. There are no changes in behavior. Tested on Ruby 3.3.

```
gems/nats-pure/lib/nats/io/jetstream.rb:14: warning: gems/nats-pure/lib/nats/io/jetstream.rb:14: warning: loading in progress, circular require considered harmful - gems/nats-pure/lib/nats/io/msg.rb
gems/nats-pure/lib/nats/io/jetstream.rb:15: warning: gems/nats-pure/lib/nats/io/jetstream.rb:15: warning: loading in progress, circular require considered harmful - gems/nats-pure/lib/nats/io/client.rb
gems/nats-pure/lib/nats/io/client.rb:623: warning: assigned but unused variable - msg_size
gems/nats-pure/lib/nats/io/client.rb:934: warning: assigned but unused variable - err
gems/nats-pure/lib/nats/io/client.rb:1181: warning: assigned but unused variable - sid
gems/nats-pure/lib/nats/io/client.rb:1818: warning: assigned but unused variable - opts
gems/nats-pure/lib/nats/io/subscription.rb:75: warning: method redefined; discarding old concurrency_semaphore
gems/nats-pure/lib/nats/io/client.rb:758: warning: method redefined; discarding old connected_server
```
