### PR TITLE
Shutdown `subscription_executor` on close and reconnect

### DIFF
--- a/scripts/nats-server
+++ b/scripts/nats-server
@@ -6,12 +6,13 @@ export DEFAULT_NATS_SERVER_VERSION=latest
 export NATS_SERVER_VERSION="${NATS_SERVER_VERSION:=$DEFAULT_NATS_SERVER_VERSION}"
 
 platform=$(uname -s)
+server_path=tmp/nats-server/nats-server-$platform-$NATS_SERVER_VERSION
 
-if [ ! -f ./tmp/nats-server/nats-server-$platform ]; then
+if [ ! -f ./$server_path ]; then
   echo "NATS server is not installed, downloading..."
   mkdir -p tmp/nats-server
   curl -sf https://binaries.nats.dev/nats-io/nats-server/v2@$NATS_SERVER_VERSION | PREFIX=$(pwd)/tmp/nats-server/ sh
-  mv tmp/nats-server/nats-server tmp/nats-server/nats-server-$platform
+  mv tmp/nats-server/nats-server $server_path
 fi
 
-./tmp/nats-server/nats-server-$platform $@
+./$server_path $@

--- a/spec/client_drain_spec.rb
+++ b/spec/client_drain_spec.rb
@@ -99,7 +99,7 @@ describe "Client - Drain" do
   end
 
   it "should report drain timeout error" do
-    nc = NATS.connect(drain_timeout: 0.5)
+    nc = NATS.connect(drain_timeout: 0.5, close_timeout: 1)
     nc2 = NATS.connect
 
     future = Future.new
@@ -157,5 +157,8 @@ describe "Client - Drain" do
     result = future.wait_for(2)
     expect(result).to eql(:error)
     expect(errors.first).to be_a(NATS::IO::DrainTimeoutError)
+
+    nc.close
+    nc2.close
   end
 end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -557,4 +557,38 @@ describe "Client - Specification" do
       end.to_not raise_error
     end
   end
+
+  describe "#close" do
+    context "when client has established a connection" do
+      let(:responder) { NATS.connect(servers: [@s.uri]) }
+      let(:requester) { NATS.connect(servers: [@s.uri]) }
+
+      it "closes all its threads" do
+        responder.subscribe("foo") { |msg| msg.respond("bar") }
+        requester.request("foo")
+
+        nats_threads = Thread.list.select do |thread|
+          thread.name&.start_with?("nats:")
+        end
+
+        requester.close
+        responder.close
+
+        expect(Thread.list & nats_threads).to be_empty
+      end
+    end
+
+    context "when client has not established a connection yet" do
+      let(:nats) { NATS::IO::Client.new }
+
+      it "closes without a hitch" do
+        nats.close
+        expect(nats.closed?).to be_truthy
+      end
+
+      it "closes all its threads" do
+        expect { nats.close }.not_to change { Thread.list.count }
+      end
+    end
+  end
 end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -560,6 +560,13 @@ describe "Client - Specification" do
 
   describe "#close" do
     context "when client has established a connection" do
+      # Close all dangling nats threads from previous tests
+      before do
+        Thread.list.each do |thread|
+          thread.exit if thread.name&.start_with?("nats:")
+        end
+      end
+
       let(:responder) { NATS.connect(servers: [@s.uri]) }
       let(:requester) { NATS.connect(servers: [@s.uri]) }
 

--- a/spec/support/nats_server_helper.rb
+++ b/spec/support/nats_server_helper.rb
@@ -99,6 +99,11 @@ class NatsServerControl
     end
   end
 
+  def restart
+    kill_server
+    start_server(true)
+  end
+
   def wait_for_server(uri, max_wait = 5) # :nodoc:
     wait = max_wait.to_f
     loop do


### PR DESCRIPTION
This is a fix for #153. 

#### Close connection

On close connection, we shut down `subscription_executor` and give subscriptions `options[:close_timeout]` (30 seconds by default) to finish their work with the NATS server. After that, we proceed with the rest of the logic. 

#### Reconnect 

On reconnection, we shut down `subscriprion_executor` by initiating an orderly termination of all in-progress tasks but do not wait for them to finish. After the threads finish their work, they will be automatically closed in the background.
