### PR TITLE
Fix ruby warnings

### DIFF
--- a/lib/nats/io/jetstream.rb
+++ b/lib/nats/io/jetstream.rb
@@ -13,9 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-require_relative "msg"
-require_relative "client"
-require_relative "errors"
 require_relative "kv"
 require_relative "jetstream/api"
 require_relative "jetstream/errors"

--- a/lib/nats/io/jetstream/msg.rb
+++ b/lib/nats/io/jetstream/msg.rb
@@ -25,4 +25,9 @@ module NATS
     module Msg
     end
   end
+
+  class Msg
+    # Enhance it with ack related methods from JetStream to ack msgs.
+    include JetStream::Msg::AckMethods
+  end
 end

--- a/lib/nats/io/msg.rb
+++ b/lib/nats/io/msg.rb
@@ -12,15 +12,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
-require_relative "jetstream"
 
 module NATS
   class Msg
     attr_accessor :subject, :reply, :data, :header
-
-    # Enhance it with ack related methods from JetStream to ack msgs.
-    include JetStream::Msg::AckMethods
 
     def initialize(opts = {})
       @subject = opts[:subject]


### PR DESCRIPTION
This is an upgraded version of #150.

The only warnings left are from third-party gems:

```sh
$ RUBYOPT="-W" be rspec

/opt/homebrew/lib/ruby/gems/3.3.0/gems/nkeys-0.1.0/lib/nkeys/keypair.rb:56: warning: method redefined; discarding old public_key
/opt/homebrew/lib/ruby/gems/3.3.0/gems/nkeys-0.1.0/lib/nkeys/keypair.rb:78: warning: method redefined; discarding old private_key

/Users/vladimirdementyev/dev/nats-pure.rb/spec/support/dns.rb:28: warning: method redefined; discarding old initialize
/opt/homebrew/lib/ruby/gems/3.3.0/gems/resolv-replace-0.1.1/lib/resolv-replace.rb:23: warning: previous definition of initialize was here

...
``` 

Closes #150 