### PR TITLE
Add Client#force_reconnect

### DIFF
--- a/gemfiles/rails6.gemfile
+++ b/gemfiles/rails6.gemfile
@@ -2,6 +2,7 @@ source "https://rubygems.org"
 
 gem "rails", "~> 6.0"
 gem "sqlite3", "~> 1.4"
+gem "concurrent-ruby", "~> 1.0", "< 1.3.5"
 
 gemspec path: ".."
 

--- a/lib/nats/io/client.rb
+++ b/lib/nats/io/client.rb
@@ -270,7 +270,7 @@ module NATS
       self
     end
 
-    def reconnect
+    def force_reconnect
       synchronize do
         return true if reconnecting?
 

--- a/spec/client_reconnect_spec.rb
+++ b/spec/client_reconnect_spec.rb
@@ -657,7 +657,7 @@ describe "Client - Reconnect" do
   end
 
   describe "#reconnect" do
-    let(:nats) { nats = NATS.connect }
+    let(:nats) { NATS.connect }
 
     context "when client is connected" do
       it "succesfully reconnects" do

--- a/spec/client_reconnect_spec.rb
+++ b/spec/client_reconnect_spec.rb
@@ -664,7 +664,7 @@ describe "Client - Reconnect" do
         reconnected = false
         nats.on_reconnect { reconnected = true }
 
-        expect(nats.reconnect).to be(true)
+        expect(nats.force_reconnect).to be(true)
         sleep 0.1 until reconnected
 
         expect(nats.stats[:reconnects]).to eq(1)
@@ -672,7 +672,7 @@ describe "Client - Reconnect" do
         nats.close
       end
 
-      it "resumes subscribtions work" do
+      it "resumes subscriptions work" do
         messages = []
 
         nats.subscribe("foo") do |msg|
@@ -684,7 +684,7 @@ describe "Client - Reconnect" do
         nats.publish("foo", "bar")
         nats.flush
 
-        nats.reconnect
+        nats.force_reconnect
 
         nats.publish("foo", "qux")
         nats.flush
@@ -712,10 +712,10 @@ describe "Client - Reconnect" do
         nats.on_reconnect { reconnected = true }
 
         # Initiate the first reconnect
-        nats.reconnect
+        nats.force_reconnect
 
         # Initiate the second reconnect
-        expect(nats.reconnect).to be(true)
+        expect(nats.force_reconnect).to be(true)
         sleep 0.1 until reconnected
 
         expect(disconnections).to eq(1)
@@ -729,7 +729,7 @@ describe "Client - Reconnect" do
       it "raises error" do
         nats.send(:close_connection, NATS::Status::DISCONNECTED, false)
 
-        expect { nats.reconnect }.to raise_error(NATS::IO::ConnectionClosedError)
+        expect { nats.force_reconnect }.to raise_error(NATS::IO::ConnectionClosedError)
       end
     end
 
@@ -737,7 +737,7 @@ describe "Client - Reconnect" do
       it "raises error" do
         nats.close
 
-        expect { nats.reconnect }.to raise_error(NATS::IO::ConnectionClosedError)
+        expect { nats.force_reconnect }.to raise_error(NATS::IO::ConnectionClosedError)
       end
     end
 
@@ -749,7 +749,7 @@ describe "Client - Reconnect" do
         nats.publish("reconnect", "draining")
         nats.drain
 
-        expect { nats.reconnect }.to raise_error(NATS::IO::ConnectionClosedError)
+        expect { nats.force_reconnect }.to raise_error(NATS::IO::ConnectionClosedError)
       end
     end
   end


### PR DESCRIPTION
## Overview

This PR implements `Client#force_reconnect` method: [Add reconnect method](https://github.com/nats-io/nats-architecture-and-design/issues/259).

Notes for the `reconnect` method:
- it does not reconnect twice if a client is already reconnecting (due to an error or manual reconnect) and returns true.
- it raises `NATS::IO::ConnectionClosedError` if a connection is closed, disconnected, or draining.
