### PR TITLE
Implement KV watchers

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
     - main
+    - 'release/**'
+    - 'dev/**'
   pull_request:
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,11 +19,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        nats_version: ["latest"]
+        nats_version: ["v2.10.25"]
         ruby: ["3.0", "3.1", "3.2", "3.3", "3.4"]
         include:
-        - nats_version: v2.10.25
+        - nats_version: main
           ruby: "3.2"
+          continue-on-error: true
+
     steps:
     - uses: actions/checkout@v4
     - uses: ruby/setup-ruby@v1

--- a/lib/nats/io/jetstream.rb
+++ b/lib/nats/io/jetstream.rb
@@ -32,6 +32,8 @@ module NATS
   #   js = nc.jetstream()
   #
   class JetStream
+    attr_reader :opts, :prefix
+
     # Create a new JetStream context for a NATS connection.
     #
     # @param conn [NATS::Client]
@@ -230,7 +232,8 @@ module NATS
       end
 
       # Enable auto acking for async callbacks unless disabled.
-      if cb && !manual_ack
+      # In case ack policy is none then we also do not require to ack.
+      if cb and !manual_ack and config.ack_policy != "none"
         ocb = cb
         new_cb = proc do |msg|
           ocb.call(msg)

--- a/lib/nats/io/jetstream.rb
+++ b/lib/nats/io/jetstream.rb
@@ -222,7 +222,6 @@ module NATS
         config.flow_control = flow_control
         if idle_heartbeat || config.idle_heartbeat
           idle_heartbeat = config.idle_heartbeat if config.idle_heartbeat
-          idle_heartbeat *= ::NATS::NANOSECONDS
           config.idle_heartbeat = idle_heartbeat
         end
 

--- a/lib/nats/io/jetstream.rb
+++ b/lib/nats/io/jetstream.rb
@@ -32,7 +32,7 @@ module NATS
   #   js = nc.jetstream()
   #
   class JetStream
-    attr_reader :opts, :prefix
+    attr_reader :opts, :prefix, :nc
 
     # Create a new JetStream context for a NATS connection.
     #

--- a/lib/nats/io/jetstream.rb
+++ b/lib/nats/io/jetstream.rb
@@ -233,7 +233,7 @@ module NATS
 
       # Enable auto acking for async callbacks unless disabled.
       # In case ack policy is none then we also do not require to ack.
-      if cb and !manual_ack and config.ack_policy != "none"
+      if cb && !manual_ack && (config.ack_policy != "none")
         ocb = cb
         new_cb = proc do |msg|
           ocb.call(msg)

--- a/lib/nats/io/jetstream/api.rb
+++ b/lib/nats/io/jetstream/api.rb
@@ -75,6 +75,8 @@ module NATS
           opts[:ack_floor] = SequenceInfo.new(opts[:ack_floor])
           opts[:delivered] = SequenceInfo.new(opts[:delivered])
           opts[:config][:ack_wait] = opts[:config][:ack_wait] / ::NATS::NANOSECONDS
+          opts[:config][:inactive_threshold] = opts[:config][:inactive_threshold] / ::NATS::NANOSECONDS if opts[:config][:inactive_threshold]
+          opts[:config][:idle_heartbeat] = opts[:config][:idle_heartbeat] / ::NATS::NANOSECONDS if opts[:config][:idle_heartbeat]
           opts[:config] = ConsumerConfig.new(opts[:config])
           opts.delete(:cluster)
           # Filter unrecognized fields just in case.

--- a/lib/nats/io/jetstream/errors.rb
+++ b/lib/nats/io/jetstream/errors.rb
@@ -42,18 +42,25 @@ module NATS
 
       # When the server responds with an error from the JetStream API.
       class APIError < Error
-        attr_reader :code, :err_code, :description, :stream, :seq
+        attr_accessor :code, :err_code, :description, :stream, :consumer, :seq
 
         def initialize(params = {})
           @code = params[:code]
           @err_code = params[:err_code]
           @description = params[:description]
           @stream = params[:stream]
+          @consumer = params[:consumer]
           @seq = params[:seq]
         end
 
         def to_s
-          "#{@description} (status_code=#{@code}, err_code=#{@err_code})"
+          if @stream && @consumer
+            "#{@description} (status_code=#{@code}, err_code=#{@err_code}, stream=#{@stream}, consumer=#{@consumer})"
+          elsif @stream
+            "#{@description} (status_code=#{@code}, err_code=#{@err_code}, stream=#{@stream})"
+          else
+            "#{@description} (status_code=#{@code}, err_code=#{@err_code})"
+          end
         end
       end
 
@@ -63,7 +70,7 @@ module NATS
       # This condition is represented with a message that has 503 status code header.
       class ServiceUnavailable < APIError
         def initialize(params = {})
-          super
+          super(params)
           @code ||= 503
         end
       end
@@ -72,7 +79,7 @@ module NATS
       # This condition is represented with a message that has 500 status code header.
       class ServerError < APIError
         def initialize(params = {})
-          super
+          super(params)
           @code ||= 500
         end
       end
@@ -81,16 +88,24 @@ module NATS
       # This condition is represented with a message that has 404 status code header.
       class NotFound < APIError
         def initialize(params = {})
-          super
+          super(params)
           @code ||= 404
         end
       end
 
       # When the stream is not found.
-      class StreamNotFound < NotFound; end
+      class StreamNotFound < NotFound
+        def initialize(params = {})
+          super(params)
+        end
+      end
 
       # When the consumer or durable is not found by name.
-      class ConsumerNotFound < NotFound; end
+      class ConsumerNotFound < NotFound
+        def initialize(params = {})
+          super(params)
+        end
+      end
 
       # When the JetStream client makes an invalid request.
       # This condition is represented with a message that has 400 status code header.

--- a/lib/nats/io/jetstream/errors.rb
+++ b/lib/nats/io/jetstream/errors.rb
@@ -70,7 +70,7 @@ module NATS
       # This condition is represented with a message that has 503 status code header.
       class ServiceUnavailable < APIError
         def initialize(params = {})
-          super(params)
+          super
           @code ||= 503
         end
       end
@@ -79,7 +79,7 @@ module NATS
       # This condition is represented with a message that has 500 status code header.
       class ServerError < APIError
         def initialize(params = {})
-          super(params)
+          super
           @code ||= 500
         end
       end
@@ -88,7 +88,7 @@ module NATS
       # This condition is represented with a message that has 404 status code header.
       class NotFound < APIError
         def initialize(params = {})
-          super(params)
+          super
           @code ||= 404
         end
       end
@@ -96,14 +96,14 @@ module NATS
       # When the stream is not found.
       class StreamNotFound < NotFound
         def initialize(params = {})
-          super(params)
+          super
         end
       end
 
       # When the consumer or durable is not found by name.
       class ConsumerNotFound < NotFound
         def initialize(params = {})
-          super(params)
+          super
         end
       end
 

--- a/lib/nats/io/jetstream/js/sub.rb
+++ b/lib/nats/io/jetstream/js/sub.rb
@@ -18,7 +18,7 @@ module NATS
   class JetStream
     module JS
       class Sub
-        attr_reader :js, :stream, :consumer, :nms
+        attr_accessor :js, :stream, :consumer, :nms
 
         def initialize(opts = {})
           @js = opts[:js]

--- a/lib/nats/io/jetstream/manager.rb
+++ b/lib/nats/io/jetstream/manager.rb
@@ -151,6 +151,10 @@ module NATS
           raise ArgumentError.new("nats: invalid inactive threshold") unless config[:inactive_threshold].is_a?(Integer)
           config[:inactive_threshold] = config[:inactive_threshold] * ::NATS::NANOSECONDS
         end
+        if config[:idle_heartbeat]
+          raise ArgumentError.new("nats: invalid idle heartbeat") unless config[:idle_heartbeat].is_a?(Integer)
+          config[:idle_heartbeat] = config[:idle_heartbeat] * ::NATS::NANOSECONDS
+        end
 
         cfg = config.to_h.compact
         req = {

--- a/lib/nats/io/jetstream/msg/ack_methods.rb
+++ b/lib/nats/io/jetstream/msg/ack_methods.rb
@@ -76,7 +76,7 @@ module NATS
         end
 
         def metadata
-          @meta ||= parse_metadata(reply)
+          @meta ||= parse_metadata(@reply)
         end
 
         private
@@ -90,6 +90,7 @@ module NATS
         end
 
         def parse_metadata(reply)
+          return unless reply && !reply.empty?
           tokens = reply.split(Ack::DotSep)
           n = tokens.count
 

--- a/lib/nats/io/jetstream/pull_subscription.rb
+++ b/lib/nats/io/jetstream/pull_subscription.rb
@@ -250,6 +250,11 @@ module NATS
           end
         end
 
+        # Check if timed out waiting for messages.
+        if msgs.empty? and MonotonicTime.since(start_time) > timeout
+          raise NATS::Timeout.new("nats: fetch timeout")
+        end
+
         msgs
       end
 

--- a/lib/nats/io/jetstream/pull_subscription.rb
+++ b/lib/nats/io/jetstream/pull_subscription.rb
@@ -251,7 +251,7 @@ module NATS
         end
 
         # Check if timed out waiting for messages.
-        if msgs.empty? and MonotonicTime.since(start_time) > timeout
+        if msgs.empty? && (MonotonicTime.since(start_time) > timeout)
           raise NATS::Timeout.new("nats: fetch timeout")
         end
 

--- a/lib/nats/io/kv.rb
+++ b/lib/nats/io/kv.rb
@@ -265,7 +265,7 @@ module NATS
       params[:meta_only] ||= false
       params[:include_history] ||= false
       params[:ignore_deletes] ||= false
-      params[:idle_heartbeat] ||= 5 # 5 seconds
+      params[:idle_heartbeat] ||= 5 # seconds
       params[:inactive_threshold] ||= 5 * 60 # 5 minutes
       subject = "#{@pre}#{keys}"
       init_setup = new_cond
@@ -472,8 +472,8 @@ module NATS
     end
 
     def stop
-      @_sub.unsubscribe
       @_hb_task.shutdown
+      @_sub.unsubscribe
     end
 
     def updates(params = {})

--- a/lib/nats/io/kv.rb
+++ b/lib/nats/io/kv.rb
@@ -406,52 +406,50 @@ module NATS
       hb_interval = params[:idle_heartbeat] * 2
       nc = @js.nc
       watcher._hb_task = Concurrent::TimerTask.new(execution_interval: hb_interval) do |task|
-        begin
-          task.shutdown if nc.closed?
-          next unless nc.connected?
+        task.shutdown if nc.closed?
+        next unless nc.connected?
 
-          # Wait for all idle heartbeats to be received, one of them would have
-          # toggled the state of the consumer back to being active.
-          active = watcher.synchronize {
-            current = watcher._active
-            # A heartbeat or another incoming message needs to toggle back.
-            watcher._active = false
-            current
-          }
-          if !active
-            ccreq = ordered.dup
-            ccreq[:deliver_policy] = "by_start_sequence"
-            ccreq[:opt_start_seq] = watcher._sseq
-            ccreq[:deliver_subject] = deliver_subject
-            ccreq[:idle_heartbeat] = ordered[:idle_heartbeat]
-            ccreq[:inactive_threshold] = ordered[:inactive_threshold]
+        # Wait for all idle heartbeats to be received, one of them would have
+        # toggled the state of the consumer back to being active.
+        active = watcher.synchronize {
+          current = watcher._active
+          # A heartbeat or another incoming message needs to toggle back.
+          watcher._active = false
+          current
+        }
+        if !active
+          ccreq = ordered.dup
+          ccreq[:deliver_policy] = "by_start_sequence"
+          ccreq[:opt_start_seq] = watcher._sseq
+          ccreq[:deliver_subject] = deliver_subject
+          ccreq[:idle_heartbeat] = ordered[:idle_heartbeat]
+          ccreq[:inactive_threshold] = ordered[:inactive_threshold]
 
-            should_recreate = false
+          should_recreate = false
+          begin
+            # Check if the original is still present, if it is then do not recreate.
             begin
-              # Check if the original is still present, if it is then do not recreate.
-              begin
-                sub.consumer_info
-              rescue ::NATS::JetStream::Error::ConsumerNotFound => e
-                e.stream ||= sub.jsi.stream
-                e.consumer ||= sub.jsi.consumer
-                @js.nc.send(:err_cb_call, @js.nc, e, sub)
-                should_recreate = true
-              end
-              next unless should_recreate
-
-              # Recreate consumer that went away after a restart.
-              cinfo = @js.add_consumer(stream_name, ccreq)
-              sub.jsi.consumer = cinfo.name
-              watcher.synchronize { watcher._dseq = 1 }
-            rescue => e
-              # Dispatch to the error NATS client error callback.
+              sub.consumer_info
+            rescue ::NATS::JetStream::Error::ConsumerNotFound => e
+              e.stream ||= sub.jsi.stream
+              e.consumer ||= sub.jsi.consumer
               @js.nc.send(:err_cb_call, @js.nc, e, sub)
+              should_recreate = true
             end
+            next unless should_recreate
+
+            # Recreate consumer that went away after a restart.
+            cinfo = @js.add_consumer(stream_name, ccreq)
+            sub.jsi.consumer = cinfo.name
+            watcher.synchronize { watcher._dseq = 1 }
+          rescue => e
+            # Dispatch to the error NATS client error callback.
+            @js.nc.send(:err_cb_call, @js.nc, e, sub)
           end
-        rescue => e
-          # WRN: Unexpected error
-          @js.nc.send(:err_cb_call, @js.nc, e, sub)
         end
+      rescue => e
+        # WRN: Unexpected error
+        @js.nc.send(:err_cb_call, @js.nc, e, sub)
       end
       watcher._hb_task.execute
 

--- a/lib/nats/io/kv/api.rb
+++ b/lib/nats/io/kv/api.rb
@@ -29,6 +29,7 @@ module NATS
         :placement,
         :republish,
         :direct,
+        :validate_keys,
         keyword_init: true
       ) do
         def initialize(opts = {})

--- a/lib/nats/io/kv/bucket_status.rb
+++ b/lib/nats/io/kv/bucket_status.rb
@@ -17,23 +17,23 @@
 module NATS
   class KeyValue
     class BucketStatus
-      attr_reader :bucket
+      attr_reader :bucket, :stream_info
 
       def initialize(info, bucket)
-        @nfo = info
+        @stream_info = info
         @bucket = bucket
       end
 
       def values
-        @nfo.state.messages
+        @stream_info.state.messages
       end
 
       def history
-        @nfo.config.max_msgs_per_subject
+        @stream_info.config.max_msgs_per_subject
       end
 
       def ttl
-        @nfo.config.max_age / ::NATS::NANOSECONDS
+        @stream_info.config.max_age / ::NATS::NANOSECONDS
       end
     end
   end

--- a/lib/nats/io/kv/errors.rb
+++ b/lib/nats/io/kv/errors.rb
@@ -73,5 +73,11 @@ module NATS
         "nats: history limited to a max of 64"
       end
     end
+
+    class InvalidKeyError < Error
+      def to_s
+        "nats: invalid key"
+      end
+    end
   end
 end

--- a/lib/nats/io/kv/errors.rb
+++ b/lib/nats/io/kv/errors.rb
@@ -59,5 +59,19 @@ module NATS
         "nats: #{@msg}"
       end
     end
+
+    # When there are no keys.
+    class NoKeysFoundError < Error
+      def to_s
+        "nats: no keys found"
+      end
+    end
+
+    # When history is too large.
+    class KeyHistoryTooLargeError < Error
+      def to_s
+        "nats: history limited to a max of 64"
+      end
+    end
   end
 end

--- a/lib/nats/io/kv/manager.rb
+++ b/lib/nats/io/kv/manager.rb
@@ -52,6 +52,11 @@ module NATS
           end
           config.ttl = config.ttl * ::NATS::NANOSECONDS
         end
+        
+        if config.history > 64
+          raise NATS::KeyValue::KeyHistoryTooLargeError
+        end
+
 
         stream = JetStream::API::StreamConfig.new(
           name: "KV_#{config.bucket}",

--- a/lib/nats/io/kv/manager.rb
+++ b/lib/nats/io/kv/manager.rb
@@ -52,11 +52,10 @@ module NATS
           end
           config.ttl = config.ttl * ::NATS::NANOSECONDS
         end
-        
+
         if config.history > 64
           raise NATS::KeyValue::KeyHistoryTooLargeError
         end
-
 
         stream = JetStream::API::StreamConfig.new(
           name: "KV_#{config.bucket}",

--- a/lib/nats/io/kv/manager.rb
+++ b/lib/nats/io/kv/manager.rb
@@ -40,6 +40,7 @@ module NATS
 
       def create_key_value(config)
         config = if !config.is_a?(KeyValue::API::KeyValueConfig)
+          config = {bucket: config} if config.is_a?(String)
           KeyValue::API::KeyValueConfig.new(config)
         else
           config

--- a/lib/nats/io/kv/manager.rb
+++ b/lib/nats/io/kv/manager.rb
@@ -17,7 +17,7 @@
 module NATS
   class KeyValue
     module Manager
-      def key_value(bucket)
+      def key_value(bucket, params = {})
         stream = "KV_#{bucket}"
         begin
           si = stream_info(stream)
@@ -33,7 +33,8 @@ module NATS
           stream: stream,
           pre: "$KV.#{bucket}.",
           js: self,
-          direct: si.config.allow_direct
+          direct: si.config.allow_direct,
+          validate_keys: params[:validate_keys]
         )
       end
 
@@ -83,7 +84,8 @@ module NATS
           stream: stream.name,
           pre: "$KV.#{config.bucket}.",
           js: self,
-          direct: si.config.allow_direct
+          direct: si.config.allow_direct,
+          validate_keys: config.validate_keys
         )
       end
 

--- a/lib/nats/io/subscription.rb
+++ b/lib/nats/io/subscription.rb
@@ -34,7 +34,7 @@ module NATS
     attr_accessor :nc
     attr_accessor :jsi
     attr_accessor :closed, :drained
-    alias :delivered :received
+    alias_method :delivered, :received
 
     def initialize(**opts)
       super() # required to initialize monitor

--- a/lib/nats/io/subscription.rb
+++ b/lib/nats/io/subscription.rb
@@ -34,6 +34,7 @@ module NATS
     attr_accessor :nc
     attr_accessor :jsi
     attr_accessor :closed, :drained
+    alias :delivered :received
 
     def initialize(**opts)
       super() # required to initialize monitor

--- a/spec/js_features_spec.rb
+++ b/spec/js_features_spec.rb
@@ -194,7 +194,10 @@ describe "JetStream" do
         sub = js.subscribe(["foo.one.1", "foo.two.2"], config: {name: "psub3"})
         info = sub.consumer_info
         expect(info.name).to eql("psub3")
-        expect(info.num_pending).to eql(3)
+
+        # Messages could have been delivered already.
+        result = info.num_ack_pending + info.num_redelivered + info.num_pending
+        expect(result).to eql(3)
 
         msgs = []
         3.times do
@@ -205,6 +208,34 @@ describe "JetStream" do
         expect(msgs[0].subject).to eql("foo.one.1")
         expect(msgs[1].subject).to eql("foo.two.2")
         expect(msgs[2].subject).to eql("foo.two.2")
+        expect(msgs.count).to eql(3)
+      end.to_not raise_error
+
+      # Create pull subscriber as well in stream with push subscribers
+      expect do
+        sub = js.pull_subscribe(["foo.one.1", "foo.two.2"], "psub4", { config: { ack_wait: 1 }})
+        info = sub.consumer_info
+        expect(info.name).to eql('psub4')
+        result = info.num_ack_pending + info.num_redelivered + info.num_pending
+        expect(result).to eql(3)
+        # drop the messages so that they are in ack pending
+        begin
+          sub.fetch(3)
+        rescue
+        end if info.num_pending > 0
+        info = sub.consumer_info
+        expect(info.num_ack_pending).to eql(3)
+        msgs = []
+        3.times do
+          fetched = sub.fetch(1)
+          fetched.each do |msg|
+            msg.ack
+            msgs << msg
+          end
+        end
+        expect(msgs[0].subject).to eql('foo.one.1')
+        expect(msgs[1].subject).to eql('foo.two.2')
+        expect(msgs[2].subject).to eql('foo.two.2')
         expect(msgs.count).to eql(3)
       end.to_not raise_error
 

--- a/spec/js_features_spec.rb
+++ b/spec/js_features_spec.rb
@@ -213,16 +213,18 @@ describe "JetStream" do
 
       # Create pull subscriber as well in stream with push subscribers
       expect do
-        sub = js.pull_subscribe(["foo.one.1", "foo.two.2"], "psub4", { config: { ack_wait: 1 }})
+        sub = js.pull_subscribe(["foo.one.1", "foo.two.2"], "psub4", {config: {ack_wait: 1}})
         info = sub.consumer_info
-        expect(info.name).to eql('psub4')
+        expect(info.name).to eql("psub4")
         result = info.num_ack_pending + info.num_redelivered + info.num_pending
         expect(result).to eql(3)
         # drop the messages so that they are in ack pending
-        begin
-          sub.fetch(3)
-        rescue
-        end if info.num_pending > 0
+        if info.num_pending > 0
+          begin
+            sub.fetch(3)
+          rescue
+          end
+        end
         info = sub.consumer_info
         expect(info.num_ack_pending).to eql(3)
         msgs = []
@@ -233,9 +235,9 @@ describe "JetStream" do
             msgs << msg
           end
         end
-        expect(msgs[0].subject).to eql('foo.one.1')
-        expect(msgs[1].subject).to eql('foo.two.2')
-        expect(msgs[2].subject).to eql('foo.two.2')
+        expect(msgs[0].subject).to eql("foo.one.1")
+        expect(msgs[1].subject).to eql("foo.two.2")
+        expect(msgs[2].subject).to eql("foo.two.2")
         expect(msgs.count).to eql(3)
       end.to_not raise_error
 

--- a/spec/js_features_spec.rb
+++ b/spec/js_features_spec.rb
@@ -14,8 +14,6 @@ describe "JetStream" do
     end
 
     it "should create pull subscribers with multiple filter subjects" do
-      skip "requires v2.10" unless ENV["NATS_SERVER_VERSION"] == "main"
-
       nc = NATS.connect(@s.uri)
       js = nc.jetstream
       js.add_stream(name: "MULTI_FILTER", subjects: ["foo.one.*", "foo.two.*", "foo.three.*"])
@@ -148,8 +146,6 @@ describe "JetStream" do
     end
 
     it "should create push subscribers with multiple filter subjects" do
-      skip "requires v2.10" unless ENV["NATS_SERVER_VERSION"] == "main"
-
       nc = NATS.connect(@s.uri)
       js = nc.jetstream
       js.add_stream(name: "MULTI_FILTER", subjects: ["foo.one.*", "foo.two.*", "foo.three.*"])
@@ -224,8 +220,6 @@ describe "JetStream" do
     end
 
     it "should create streams and customers with metadata" do
-      skip "requires v2.10" unless ENV["NATS_SERVER_VERSION"] == "main"
-
       nc = NATS.connect(@s.uri)
       js = nc.jetstream
       stream = js.add_stream({

--- a/spec/js_features_spec.rb
+++ b/spec/js_features_spec.rb
@@ -164,7 +164,7 @@ describe "JetStream" do
         expect(info.name).to eql("MULTI_FILTER_CONSUMER")
         expect(info.config.durable_name).to eql("MULTI_FILTER_CONSUMER")
         expect(info.config.max_waiting).to eql(nil)
-        expect(info.num_pending).to eql(3)
+        expect(info.num_pending + info.num_ack_pending).to eql(3)
 
         msgs = []
         3.times do

--- a/spec/js_spec.rb
+++ b/spec/js_spec.rb
@@ -956,7 +956,7 @@ describe "JetStream" do
           ack_policy: "explicit",
           max_ack_pending: 20,
           max_waiting: 3,
-          ack_wait: 5 * 1_000_000_000 # 5 seconds
+          ack_wait: 5 # seconds
         }
       }
       resp = nc.jsm(domain: @domain).add_consumer(stream_name, consumer_req[:config])

--- a/spec/js_spec.rb
+++ b/spec/js_spec.rb
@@ -899,6 +899,15 @@ describe "JetStream" do
 
       js = nc.jetstream(domain: "estre")
       info = js.account_info
+
+      # v2.11 starts to include API levels.
+      api_hash = nil
+      if ENV['NATS_SERVER_VERSION'] == "main"
+        api_hash = {total: 5, errors: 0, level: 1}
+      else
+        api_hash = {total: 5, errors: 0}
+      end
+
       expected = a_hash_including({
         type: "io.nats.jetstream.api.v1.account_info_response",
         memory: 0,
@@ -916,15 +925,12 @@ describe "JetStream" do
           max_bytes_required: false
         }),
         domain: "estre",
-        api: {total: 5, errors: 0}
+        api: api_hash,
       })
 
       # Filter these out
       info.delete(:reserved_memory) if info[:reserved_memory]
       info.delete(:reserved_storage) if info[:reserved_storage]
-
-      # v2.11 starts to include API levels.
-      expected[:api][:level] = 1 if ENV['NATS_SERVER_VERSION'] == "main"
 
       expect(info).to match(expected)
     end

--- a/spec/js_spec.rb
+++ b/spec/js_spec.rb
@@ -918,6 +918,14 @@ describe "JetStream" do
         domain: "estre",
         api: {total: 5, errors: 0}
       })
+
+      # Filter these out
+      info.delete(:reserved_memory) if info[:reserved_memory]
+      info.delete(:reserved_storage) if info[:reserved_storage]
+
+      # v2.11 starts to include API levels.
+      expected[:api][:level] = 1 if ENV['NATS_SERVER_VERSION'] == "main"
+
       expect(info).to match(expected)
     end
 

--- a/spec/js_spec.rb
+++ b/spec/js_spec.rb
@@ -602,10 +602,10 @@ describe "JetStream" do
       cinfo = js.add_consumer("ctests",
         name: consumer_name,
         durable_name: consumer_name,
-        inactive_threshold: 2,
+        inactive_threshold: 2, # seconds
         ack_policy: "explicit",
         mem_storage: true)
-      expect(cinfo.config.inactive_threshold).to eql(2000000000)
+      expect(cinfo.config.inactive_threshold).to eql(2)
       expect(cinfo.config.mem_storage).to eql(true)
     end
   end

--- a/spec/js_spec.rb
+++ b/spec/js_spec.rb
@@ -901,11 +901,10 @@ describe "JetStream" do
       info = js.account_info
 
       # v2.11 starts to include API levels.
-      api_hash = nil
-      if ENV['NATS_SERVER_VERSION'] == "main"
-        api_hash = {total: 5, errors: 0, level: 1}
+      api_hash = if ENV["NATS_SERVER_VERSION"] == "main"
+        {total: 5, errors: 0, level: 1}
       else
-        api_hash = {total: 5, errors: 0}
+        {total: 5, errors: 0}
       end
 
       expected = a_hash_including({
@@ -925,7 +924,7 @@ describe "JetStream" do
           max_bytes_required: false
         }),
         domain: "estre",
-        api: api_hash,
+        api: api_hash
       })
 
       # Filter these out

--- a/spec/kv_spec.rb
+++ b/spec/kv_spec.rb
@@ -136,6 +136,15 @@ describe "KeyValue" do
     )
     expect(config).to eql(si.config)
 
+    # v2.11 changes
+    if ENV['NATS_SERVER_VERSION'] == "main"
+      config.metadata = {
+        :"_nats.level" => "1",
+        :"_nats.ver"   => "2.11.0-dev",
+        :"_nats.req.level" => "0"
+      }
+    end
+
     # Nothing from start
     expect do
       kv.get("name")

--- a/spec/kv_spec.rb
+++ b/spec/kv_spec.rb
@@ -135,11 +135,11 @@ describe "KeyValue" do
       mirror_direct: false
     )
     # v2.11 changes
-    if ENV['NATS_SERVER_VERSION'] == "main"
+    if ENV["NATS_SERVER_VERSION"] == "main"
       config.metadata = {
-        :"_nats.level" => "1",
-        :"_nats.ver"   => "2.11.0-dev",
-        :"_nats.req.level" => "0"
+        "_nats.level": "1",
+        "_nats.ver": "2.11.0-dev",
+        "_nats.req.level": "0"
       }
     end
     expect(config).to eql(si.config)
@@ -393,14 +393,14 @@ describe "KeyValue" do
     nc.close
   end
 
-  major, minor, patch = RUBY_VERSION.split('.')
-  it 'should support watch' do
-    skip 'watch requires ruby >= 3.2' if major >= '3' and minor < '2'
+  major, minor, _ = RUBY_VERSION.split(".")
+  it "should support watch" do
+    skip "watch requires ruby >= 3.2" if (major >= "3") && (minor < "2")
 
     nc = NATS.connect(@s.uri)
     js = nc.jetstream
     kv = js.create_key_value(
-      bucket: "WATCH",
+      bucket: "WATCH"
     )
 
     # Same as watch all the updates.
@@ -413,51 +413,51 @@ describe "KeyValue" do
 
     kv.create("name", "alice:1")
     e = w.updates
-    expect(e.delta) == 0
-    expect(e.key) == 'name'
-    expect(e.value) == 'alice:1'
-    expect(e.revision) == 1
+    expect(e.delta).to eql(0)
+    expect(e.key).to eql("name")
+    expect(e.value).to eql("alice:1")
+    expect(e.revision).to eql(1)
 
     kv.put("name", "alice:2")
     e = w.updates
-    expect(e.key) == 'name'
-    expect(e.value) == 'alice:2'
-    expect(e.revision) == 2
+    expect(e.key).to eql("name")
+    expect(e.value).to eql("alice:2")
+    expect(e.revision).to eql(2)
 
     kv.put("name", "alice:3")
     e = w.updates
-    expect(e.key) == 'name'
-    expect(e.value) == 'alice:3'
-    expect(e.revision) == 3
+    expect(e.key).to eql("name")
+    expect(e.value).to eql("alice:3")
+    expect(e.revision).to eql(3)
 
     kv.put("age", "22")
     e = w.updates
-    expect(e.key) == 'age'
-    expect(e.value) == '22'
-    expect(e.revision) == 4
+    expect(e.key).to eql('age')
+    expect(e.value).to eql('22')
+    expect(e.revision).to eql(4)
 
     kv.put("age", "33")
     e = w.updates
-    expect(e.bucket) == 'WATCH'
-    expect(e.key) == 'age'
-    expect(e.value) == '33'
-    expect(e.revision) == 5
+    expect(e.bucket).to eql("WATCH")
+    expect(e.key).to eql("age")
+    expect(e.value).to eql('33')
+    expect(e.revision).to eql(5)
 
-    kv.delete('age')
+    kv.delete("age")
     e = w.updates
-    expect(e.bucket) == 'WATCH'
-    expect(e.key) == 'age'
-    expect(e.value) == ''
-    expect(e.revision) == 6
-    expect(e.operation) == 'DEL'
+    expect(e.bucket).to eql('WATCH')
+    expect(e.key).to eql('age')
+    expect(e.value).to eql('')
+    expect(e.revision).to eql(6)
+    expect(e.operation).to eql('DEL')
 
-    kv.purge('name')
+    kv.purge("name")
     e = w.updates
-    expect(e.bucket) == 'WATCH'
-    expect(e.key) == 'name'
-    expect(e.value) == ''
-    expect(e.revision) == 7
-    expect(e.operation) == 'PURGE'
+    expect(e.bucket).to eql('WATCH')
+    expect(e.key).to eql('name')
+    expect(e.value).to eql('')
+    expect(e.revision).to eql(7)
+    expect(e.operation).to eql('PURGE')
 
     # No new updates at this point...
     expect do
@@ -530,21 +530,22 @@ describe "KeyValue" do
 
     # Default watch timeout should 5 minutes
     ci = js.consumer_info("KV_WATCH", w._sub.jsi.consumer)
-    ci.config.inactive_threshold == 300.0
+    expect(ci.config.idle_heartbeat).to eql(5)
+    expect(ci.config.inactive_threshold).to eql(300)
 
     # using meta only
     w = kv.watchall(meta_only: true)
     entries = w.take(2)
-    expect(entries.first.key).to eql('age')
+    expect(entries.first.key).to eql("age")
     expect(entries.first.value).to be_empty
-    expect(entries.last.key).to eql('name')
+    expect(entries.last.key).to eql("name")
     expect(entries.last.value).to be_empty
 
     nc.close
   end
 
-  it 'should support history' do
-    skip 'watch requires ruby >= 3.2' if major >= '3' and minor < '2'
+  it "should support history" do
+    skip "watch requires ruby >= 3.2" if (major >= "3") && (minor < "2")
 
     nc = NATS.connect(@s.uri)
     nc.on_error do |e|
@@ -558,14 +559,14 @@ describe "KeyValue" do
     status = kv.status
     expect(status.stream_info.config.max_msgs_per_subject).to eql(10)
 
-    50.times { |i| kv.put("age", "#{i}") }
+    50.times { |i| kv.put("age", i.to_s) }
 
     vl = kv.history("age").to_a
     expect(vl.size).to eql(10)
 
     i = 0
     vl.each do |entry|
-      expect(entry.key).to eql('age')
+      expect(entry.key).to eql("age")
       expect(entry.revision).to eql(i + 41)
       expect(entry.value.to_i).to eql(i + 40)
       i += 1
@@ -586,11 +587,11 @@ describe "KeyValue" do
     nc.close
   end
 
-  it 'should support using watchers as enumerables' do
+  it "should support using watchers as enumerables" do
     nc = NATS.connect(@s.uri)
     js = nc.jetstream
     kv = js.create_key_value(
-      bucket: "WATCH",
+      bucket: "WATCH"
     )
 
     w = kv.watch("users.*")
@@ -618,13 +619,13 @@ describe "KeyValue" do
 
     # Can still peek after stopped.
     entries = w.take(1)
-    expect(entries.first.key).to eql('users.21')
+    expect(entries.first.key).to eql("users.21")
 
     nc.close
   end
 
-  it 'should support keys' do
-    skip 'watch requires ruby >= 3.2' if major >= '3' and minor < '2'
+  it "should support keys" do
+    skip "watch requires ruby >= 3.2" if (major >= "3") && (minor < "2")
 
     nc = NATS.connect(@s.uri)
     nc.on_error do |e|
@@ -642,12 +643,12 @@ describe "KeyValue" do
     end.to raise_error NATS::KeyValue::NoKeysFoundError
     expect(kv.status.stream_info.config.max_msgs_per_subject).to eql(2)
 
-    kv.put("a", '1')
-    kv.put("b", '2')
-    kv.put("a", '11')
-    kv.put("b", '22')
-    kv.put("a", '111')
-    kv.put("b", '222')
+    kv.put("a", "1")
+    kv.put("b", "2")
+    kv.put("a", "11")
+    kv.put("b", "22")
+    kv.put("a", "111")
+    kv.put("b", "222")
 
     keys = kv.keys.to_a
     expect(keys.size).to eql(2) # last_per_subject
@@ -663,24 +664,24 @@ describe "KeyValue" do
     kv.delete("a")
 
     # Should skip deleted entries
-    keys = kv.keys.select { |key|  key == 'a' }
+    keys = kv.keys.select { |key| key == "a" }
     expect(keys.size).to eql(0)
-    keys = kv.keys.reject { |key|  key == 'a' }
+    keys = kv.keys.reject { |key| key == "a" }
     expect(keys.size).to eql(1)
     kv.keys do |key|
-      expect(key).to_not eql('a')
+      expect(key).to_not eql("a")
     end
-    expect(kv.keys.to_a).to eql(['b'])
+    expect(kv.keys.to_a).to eql(["b"])
 
-    kv.purge('b')
+    kv.purge("b")
 
     expect do
       kv.keys.take(1)
     end.to raise_error NATS::KeyValue::NoKeysFoundError
 
-    kv.create("c", '3')
+    kv.create("c", "3")
     expect(kv.keys.to_a.size).to eql(1)
-    expect(kv.keys.to_a).to eql(['c'])
+    expect(kv.keys.to_a).to eql(["c"])
 
     nc.close
   end

--- a/spec/kv_spec.rb
+++ b/spec/kv_spec.rb
@@ -618,6 +618,7 @@ describe "KeyValue" do
     expect(entries.last.key).to eql("users.20")
 
     w.stop
+    expect(w._hb_task.running?).to eql(false)
 
     # Can still peek after stopped.
     entries = w.take(1)
@@ -778,8 +779,12 @@ describe "KeyValue" do
       entries.push(entry)
       break if entries.size > 20
     end
+    w.stop
 
     nc.close
     nc2.close
+
+    # Make sure watcher timers not running anymore after closing connection.
+    expect(w._hb_task.running?).to eql(false)
   end
 end

--- a/spec/kv_spec.rb
+++ b/spec/kv_spec.rb
@@ -134,8 +134,6 @@ describe "KeyValue" do
       allow_direct: false,
       mirror_direct: false
     )
-    expect(config).to eql(si.config)
-
     # v2.11 changes
     if ENV['NATS_SERVER_VERSION'] == "main"
       config.metadata = {
@@ -144,6 +142,7 @@ describe "KeyValue" do
         :"_nats.req.level" => "0"
       }
     end
+    expect(config).to eql(si.config)
 
     # Nothing from start
     expect do

--- a/spec/kv_spec.rb
+++ b/spec/kv_spec.rb
@@ -432,32 +432,32 @@ describe "KeyValue" do
 
     kv.put("age", "22")
     e = w.updates
-    expect(e.key).to eql('age')
-    expect(e.value).to eql('22')
+    expect(e.key).to eql("age")
+    expect(e.value).to eql("22")
     expect(e.revision).to eql(4)
 
     kv.put("age", "33")
     e = w.updates
     expect(e.bucket).to eql("WATCH")
     expect(e.key).to eql("age")
-    expect(e.value).to eql('33')
+    expect(e.value).to eql("33")
     expect(e.revision).to eql(5)
 
     kv.delete("age")
     e = w.updates
-    expect(e.bucket).to eql('WATCH')
-    expect(e.key).to eql('age')
-    expect(e.value).to eql('')
+    expect(e.bucket).to eql("WATCH")
+    expect(e.key).to eql("age")
+    expect(e.value).to eql("")
     expect(e.revision).to eql(6)
-    expect(e.operation).to eql('DEL')
+    expect(e.operation).to eql("DEL")
 
     kv.purge("name")
     e = w.updates
-    expect(e.bucket).to eql('WATCH')
-    expect(e.key).to eql('name')
-    expect(e.value).to eql('')
+    expect(e.bucket).to eql("WATCH")
+    expect(e.key).to eql("name")
+    expect(e.value).to eql("")
     expect(e.revision).to eql(7)
-    expect(e.operation).to eql('PURGE')
+    expect(e.operation).to eql("PURGE")
 
     # No new updates at this point...
     expect do

--- a/spec/kv_spec.rb
+++ b/spec/kv_spec.rb
@@ -393,7 +393,10 @@ describe "KeyValue" do
     nc.close
   end
 
+  major, minor, patch = RUBY_VERSION.split('.')
   it 'should support watch' do
+    skip 'watch requires ruby >= 3.2' if major >= '3' and minor < '2'
+
     nc = NATS.connect(@s.uri)
     js = nc.jetstream
     kv = js.create_key_value(
@@ -541,6 +544,8 @@ describe "KeyValue" do
   end
 
   it 'should support history' do
+    skip 'watch requires ruby >= 3.2' if major >= '3' and minor < '2'
+
     nc = NATS.connect(@s.uri)
     nc.on_error do |e|
       puts e
@@ -555,7 +560,7 @@ describe "KeyValue" do
 
     50.times { |i| kv.put("age", "#{i}") }
 
-    vl = kv.history("age")
+    vl = kv.history("age").to_a
     expect(vl.size).to eql(10)
 
     i = 0
@@ -619,6 +624,8 @@ describe "KeyValue" do
   end
 
   it 'should support keys' do
+    skip 'watch requires ruby >= 3.2' if major >= '3' and minor < '2'
+
     nc = NATS.connect(@s.uri)
     nc.on_error do |e|
       puts e
@@ -645,9 +652,9 @@ describe "KeyValue" do
     keys = kv.keys.to_a
     expect(keys.size).to eql(2) # last_per_subject
 
-    # Using a block
+    # Using a block with each
     keys = []
-    kv.keys do |entry|
+    kv.keys.each do |entry|
       keys.append(entry)
     end
     expect(keys.size).to eql(2)


### PR DESCRIPTION
Example usage:

```ruby
# Using a queue 
w = kv.watchall
entry = w.updates

# As Enumerables (requires at least Ruby 3.2)
entries = kv.watchall.take(10)

# Using a block
kv.watchall.each do |entry|
  puts "#{entry.key} -- #{entry.value}"   
end  

# Gather all keys
keys = kv.keys.to_a
puts keys
```

Also includes other reliability fixes.