### PR TITLE
Misc Fixes 

### DIFF
--- a/examples/service_api/basic.rb
+++ b/examples/service_api/basic.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "nats"
+
 client = NATS.connect
 
 service = client.services.add(

--- a/examples/service_api/discovery.rb
+++ b/examples/service_api/discovery.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "nats"
+
 client = NATS.connect
 
 service = client.services.add(

--- a/examples/service_api/errors.rb
+++ b/examples/service_api/errors.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "nats"
+
 client = NATS.connect
 
 service = client.services.add(

--- a/examples/service_api/groups.rb
+++ b/examples/service_api/groups.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "nats"
+
 client = NATS.connect
 
 service = client.services.add(

--- a/examples/service_api/stats.rb
+++ b/examples/service_api/stats.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "nats"
+
 client = NATS.connect
 
 service = client.services.add(

--- a/lib/nats.rb
+++ b/lib/nats.rb
@@ -14,6 +14,8 @@
 # limitations under the License.
 #
 
+require "nats/utils/list"
+require "nats/service"
 require "nats/io/client"
 require "nats/nuid"
 

--- a/lib/nats.rb
+++ b/lib/nats.rb
@@ -15,8 +15,8 @@
 #
 
 require "nats/utils/list"
-require "nats/service"
 require "nats/io/client"
+require "nats/service"
 require "nats/nuid"
 
 # A thread safe Ruby client for the NATS messaging system (https://nats.io).

--- a/lib/nats/client.rb
+++ b/lib/nats/client.rb
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+require "nats/utils/list"
 require "nats/io/client"
+require "nats/service"
 require "nats/io/rails" if defined?(Rails::Engine)
 require "nats/nuid"

--- a/lib/nats/io/client.rb
+++ b/lib/nats/io/client.rb
@@ -101,7 +101,7 @@ module NATS
     include MonitorMixin
     include Status
 
-    attr_reader :status, :server_info, :server_pool, :options, :stats, :uri, :subscription_executor, :reloader, :services
+    attr_reader :status, :server_info, :server_pool, :options, :stats, :uri, :subscription_executor, :reloader
 
     DEFAULT_PORT = {nats: 4222, ws: 80, wss: 443}.freeze
     DEFAULT_URI = "nats://localhost:#{DEFAULT_PORT[:nats]}".freeze
@@ -243,7 +243,7 @@ module NATS
       @drain_t = nil
 
       # Service API
-      @services = Services.new(self)
+      @_services = nil
 
       # Prepare for calling connect or automatic delayed connection
       parse_and_validate_options if uri || opts.any?
@@ -858,6 +858,10 @@ module NATS
     end
     alias_method :JetStream, :jetstream
     alias_method :jsm, :jetstream
+
+    def services
+      synchronize { @_services ||= Services.new(self) }
+    end
 
     private
 

--- a/lib/nats/io/msg.rb
+++ b/lib/nats/io/msg.rb
@@ -16,7 +16,7 @@
 module NATS
   class Msg
     attr_accessor :subject, :reply, :data, :header
-    attr_reader :error
+    attr_accessor :nc, :sub
 
     def initialize(opts = {})
       @subject = opts[:subject]
@@ -25,9 +25,10 @@ module NATS
       @header = opts[:header]
       @nc = opts[:nc]
       @sub = opts[:sub]
+
+      # JS related
       @ackd = false
       @meta = nil
-      @error = nil
     end
 
     def respond(data = "")
@@ -40,22 +41,6 @@ module NATS
       else
         @nc.publish(reply, data)
       end
-    end
-
-    def respond_with_error(error)
-      @error = NATS::Service::ErrorWrapper.new(error)
-
-      message = dup
-      message.subject = reply
-      message.reply = ""
-      message.data = @error.data
-
-      message.header = {
-        "Nats-Service-Error" => @error.message,
-        "Nats-Service-Error-Code" => @error.code
-      }
-
-      respond_msg(message)
     end
 
     def respond_msg(msg)

--- a/lib/nats/service/endpoint.rb
+++ b/lib/nats/service/endpoint.rb
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-
 module NATS
   class Service
     class Request < ::NATS::Msg

--- a/lib/nats/service/endpoint.rb
+++ b/lib/nats/service/endpoint.rb
@@ -116,8 +116,9 @@ module NATS
         service.client.subscribe(subject, queue: queue) do |msg|
           started_at = Time.now
 
-          block.call(Request.from_msg(self, msg))
-          stats.error(msg.error) if msg.error
+          req = Request.from_msg(self, msg)
+          block.call(req)
+          stats.error(req.error) if req.error
         rescue NATS::Error => error
           stats.error(error)
           service.stop(error)

--- a/lib/nats/service/endpoint.rb
+++ b/lib/nats/service/endpoint.rb
@@ -1,7 +1,68 @@
 # frozen_string_literal: true
 
+# Copyright 2025 The NATS Authors
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+
 module NATS
   class Service
+    class Request < ::NATS::Msg
+      attr_reader :error, :endpoint
+
+      def initialize(opts = {})
+        super
+        @endpoint = opts[:endpoint]
+        @error = nil
+      end
+
+      def respond_with_error(error)
+        @error = NATS::Service::ErrorWrapper.new(error)
+
+        message = dup
+        message.subject = reply
+        message.reply = ""
+        message.data = @error.data
+
+        message.header = {
+          "Nats-Service-Error" => @error.message,
+          "Nats-Service-Error-Code" => @error.code
+        }
+
+        respond_msg(message)
+      end
+
+      def inspect
+        dot = "..." if @data.length > 10
+        dat = "#{data.slice(0, 10)}#{dot}"
+        "#<Service::Request(subject: \"#{@subject}\", reply: \"#{@reply}\", data: #{dat.inspect})>"
+      end
+
+      class << self
+        def from_msg(svc, msg)
+          request = Request.new(endpoint: svc)
+          request.subject = msg.subject
+          request.reply = msg.reply
+          request.data = msg.data
+          request.header = msg.header
+          request.nc = msg.nc
+          request.sub = msg.sub
+
+          request
+        end
+      end
+    end
+
     class Endpoint
       attr_reader :name, :service, :subject, :metadata, :queue, :stats
 
@@ -57,7 +118,7 @@ module NATS
         service.client.subscribe(subject, queue: queue) do |msg|
           started_at = Time.now
 
-          block.call(msg)
+          block.call(Request.from_msg(self, msg))
           stats.error(msg.error) if msg.error
         rescue NATS::Error => error
           stats.error(error)
@@ -66,7 +127,7 @@ module NATS
           raise error
         rescue => error
           stats.error(error)
-          msg.respond_with_error(error)
+          Request.from_msg(self, msg).respond_with_error(error)
         ensure
           stats.record(started_at)
         end

--- a/spec/kv_spec.rb
+++ b/spec/kv_spec.rb
@@ -59,6 +59,8 @@ describe "KeyValue" do
     expect do
       js.key_value("TEST")
     end.to raise_error(NATS::KeyValue::BucketNotFoundError)
+
+    nc.close
   end
 
   it "should report when bucket is not found or invalid" do
@@ -82,6 +84,8 @@ describe "KeyValue" do
     expect do
       js.key_value("foo")
     end.to raise_error(NATS::KeyValue::BadBucketError)
+
+    nc.close
   end
 
   it "should support access to KeyValue stores from multiple instances" do
@@ -732,7 +736,7 @@ describe "KeyValue" do
   end
 
   it "should reconnect watches on server restart" do
-    tmpdir = Dir.mktmpdir("ruby-jetstream")
+    tmpdir = Dir.mktmpdir("ruby-jetstream2")
     @s2 = NatsServerControl.new("nats://127.0.0.1:4631", "/tmp/test-nats.pid", "-js -sd=#{tmpdir}")
     @s2.start_server(true)
     s = @s2
@@ -786,5 +790,11 @@ describe "KeyValue" do
 
     # Make sure watcher timers not running anymore after closing connection.
     expect(w._hb_task.running?).to eql(false)
+
+    begin
+      @s2.kill_server
+    ensure
+      FileUtils.remove_entry(tmpdir)
+    end
   end
 end

--- a/spec/service/request_spec.rb
+++ b/spec/service/request_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe NATS::Msg do
+RSpec.describe NATS::Service::Request do
   subject { described_class.new(options) }
 
   let(:options) do

--- a/spec/support/nats_server_helper.rb
+++ b/spec/support/nats_server_helper.rb
@@ -86,7 +86,7 @@ class NatsServerControl
       system("#{BIN_PATH} #{args} 2> /dev/null &")
     end
     exitstatus = $?.exitstatus
-    wait_for_server(@uri, 10) if wait_for_server
+    wait_for_server(@uri, 60) if wait_for_server
     exitstatus
   end
 


### PR DESCRIPTION
- Initialize `Services` on demand to support `require 'nats/client'` or `require 'nats'` imports
- Fixes to KV watches and specs
- Add Service::Request type to avoid adding service logic to default Msg