### PR TITLE
Added filtering to KV method returning all keys

### DIFF
--- a/lib/nats/io/kv.rb
+++ b/lib/nats/io/kv.rb
@@ -215,20 +215,29 @@ module NATS
 
     # keys returns the keys from a KeyValue store.
     # Optionally filters the keys based on the provided filter list.
-    def keys(params = {})
+    def keys(params = {}, filters = [])
       params[:ignore_deletes] = true
       params[:meta_only] = true
 
-      w = watchall(params)
+      filters = [filters] unless filters.is_a?(Enumerable)
+      w = if filters.empty?
+        [watchall(params)]
+      else
+        filters.collect do |filter|
+          watch(filter, params)
+        end
+      end
       got_keys = false
 
       Enumerator.new do |y|
-        w.each do |entry|
-          break if entry.nil?
-          got_keys = true
-          y << entry.key
+        w.each do |filter|
+          filter.each do |entry|
+            break if entry.nil?
+            got_keys = true
+            y << entry.key
+          end
         end
-        w.stop
+        w.each { |filter| filter.stop }
         raise NoKeysFoundError unless got_keys
       end
     end

--- a/sig/nats/io/kv.rbs
+++ b/sig/nats/io/kv.rbs
@@ -10,14 +10,14 @@ module NATS
     @name: String
     @stream: String
     @pre: String
-    @js: NATS::JetStream
+    @js: JetStream
     @direct: bool
 
     def initialize: (Hash[Symbol, untyped]) -> void
 
-    def get: (String, ?Hash[Symbol, untyped]) -> NATS::KeyValue::Entry
+    def get: (String, ?Hash[Symbol, untyped]) -> Entry
 
-    private def _get: (String, ?Hash[Symbol, untyped]) -> NATS::KeyValue::Entry
+    private def _get: (String, ?Hash[Symbol, untyped]) -> Entry
 
     def put: (String, untyped) -> Integer
 
@@ -29,11 +29,32 @@ module NATS
 
     def delete: (String, ?Hash[Symbol, untyped]) -> Integer
 
-    def purge: (String) -> NATS::JetStream::PubAck
+    def purge: (String) -> JetStream::PubAck
 
-    def status: () -> NATS::KeyValue::BucketStatus
+    def status: () -> BucketStatus
 
     class Entry < Struct[untyped]
+
+    def watchall: (?Hash[Symbol, untyped]) -> KeyWatcher
+
+    def keys: (?Hash[Symbol, untyped], ?Enumerable[String]) -> Enumerator[String]
+
+    def history: (String, ?Hash[Symbol, untyped]) -> Enumerator[String]
+
+    STATUS_HDR: 'Status'
+    DESC_HDR: 'Description'
+    CTRL_STATUS: '100'
+    LAST_CONSUMER_SEQ_HDR: 'Nats-Last-Consumer'
+    LAST_STREAM_SEQ_HDR: 'Nats-Last-Stream'
+    CONSUMER_STALLED_HDR: 'Nats-Consumer-Stalled'
+
+    def watch: (String, ?Hash[Symbol, untyped]) -> KeyWatcher
+
+    class KeyWatcher
+      include MonitorMixin
+      include Enumerable[untyped]
+
+      def initialize: (NATS::JetStream) -> void
     end
   end
 end

--- a/spec/kv_spec.rb
+++ b/spec/kv_spec.rb
@@ -660,6 +660,10 @@ describe "KeyValue" do
     keys = kv.keys.to_a
     expect(keys.size).to eql(2) # last_per_subject
 
+    # Filtered keys
+    keys = kv.keys({}, "a").to_a
+    expect(keys.size).to eql(1)
+
     # Using a block with each
     keys = []
     kv.keys.each do |entry|


### PR DESCRIPTION
Adds key filtering to resolve: #147.

# Note
In future It might be worth making the breaking change to `keys` or to add a new method `filtered_keys`. I wasn't sure how well that would look/be used.
For now I have opted to do a non-breaking change to the `keys` method, just looks a little rough at the moment.