### PR TITLE
#feature

### DIFF
--- a/lib/nats/io/client.rb
+++ b/lib/nats/io/client.rb
@@ -1747,7 +1747,8 @@ module NATS
       socket_class.new(
         uri: @uri,
         tls: {context: tls_context, hostname: @hostname},
-        connect_timeout: NATS::IO::DEFAULT_CONNECT_TIMEOUT
+        connect_timeout: NATS::IO::DEFAULT_CONNECT_TIMEOUT,
+        **@initial_options
       )
     end
 

--- a/lib/nats/io/websocket.rb
+++ b/lib/nats/io/websocket.rb
@@ -19,6 +19,7 @@ module NATS
 
       def initialize(options = {})
         super
+        @options = options
       end
 
       def connect
@@ -26,7 +27,7 @@ module NATS
 
         setup_tls! if @uri.scheme == "wss" # WebSocket connection must be made over TLS from the beginning
 
-        @handshake = ::WebSocket::Handshake::Client.new url: @uri.to_s
+        @handshake = ::WebSocket::Handshake::Client.new url: @uri.to_s, **@options
         @frame = ::WebSocket::Frame::Incoming::Client.new
         @handshaked = false
 


### PR DESCRIPTION
Add support for additional connect parameters. Allow passing custom headers to WSS handshake block.

Example:
NATS.connect NATS_URL, headers: { cookie: 'auth_token=eyJhbGciOiJFZERTQSJ9' }

#171 