### PR TITLE
Fix KV watcher consumer recreation for empty buckets

### DIFF
--- a/lib/nats/io/kv.rb
+++ b/lib/nats/io/kv.rb
@@ -424,8 +424,15 @@ module NATS
         }
         if !active
           ccreq = ordered.dup
-          ccreq[:deliver_policy] = "by_start_sequence"
-          ccreq[:opt_start_seq] = watcher._sseq
+          # When bucket is empty, watcher._sseq remains 0. JetStream rejects
+          # consumer creation with opt_start_seq=0 (err_code=10094).
+          # Keep original deliver_policy in that case.
+          if watcher._sseq.to_i > 0
+            ccreq[:deliver_policy] = "by_start_sequence"
+            ccreq[:opt_start_seq] = watcher._sseq
+          else
+            ccreq.delete(:opt_start_seq)
+          end
           ccreq[:deliver_subject] = deliver_subject
           ccreq[:idle_heartbeat] = ordered[:idle_heartbeat]
           ccreq[:inactive_threshold] = ordered[:inactive_threshold]

--- a/spec/kv_spec.rb
+++ b/spec/kv_spec.rb
@@ -797,4 +797,67 @@ describe "KeyValue" do
       FileUtils.remove_entry(tmpdir)
     end
   end
+
+  it "should reconnect watches on server restart with empty bucket" do
+    tmpdir = Dir.mktmpdir("ruby-jetstream-empty-bucket")
+    @s2 = NatsServerControl.new("nats://127.0.0.1:4632", "/tmp/test-nats-empty.pid", "-js -sd=#{tmpdir}")
+    @s2.start_server(true)
+    s = @s2
+
+    nc = NATS.connect(s.uri)
+    errors = []
+    nc.on_error do |e|
+      errors << e
+    end
+    js = nc.jetstream
+
+    kv = js.create_key_value("EMPTY_TEST")
+
+    # Use short idle_heartbeat to speed up the test (hb_task runs every 2s)
+    w = kv.watchall(idle_heartbeat: 1)
+
+    initial_entry = w.updates(timeout: 2)
+    expect(initial_entry).to be_nil
+
+    # Key condition: watcher._sseq == 0 triggers the bug without the fix
+    expect(w._sseq).to eql(0)
+
+    Thread.new do
+      sleep 0.5
+      s.kill_server
+      sleep 1
+      @s2.start_server(true)
+    end
+
+    # Wait for hb_task to detect ConsumerNotFound and recreate consumer
+    sleep 5
+
+    # Without the fix, hb_task would fail with err_code=10094 when trying
+    # to create consumer with deliver_policy=by_start_sequence and opt_start_seq=0
+    bad_request_errors = errors.select do |e|
+      e.is_a?(NATS::JetStream::Error::BadRequest) && e.err_code == 10094
+    end
+    expect(bad_request_errors).to be_empty
+
+    # Verify watcher still works after reconnection
+    nc2 = NATS.connect(s.uri)
+    js2 = nc2.jetstream
+    kv2 = js2.key_value("EMPTY_TEST")
+    kv2.put("test_key", "test_value")
+
+    entry = w.updates(timeout: 3)
+    expect(entry).not_to be_nil
+    expect(entry.key).to eql("test_key")
+    expect(entry.value).to eql("test_value")
+
+    w.stop
+    nc.close
+    nc2.close
+
+    begin
+      @s2.kill_server
+    ensure
+      FileUtils.remove_entry(tmpdir)
+    end
+  end
 end


### PR DESCRIPTION
## Problem

When a NATS server restarts, the KV watcher's heartbeat task (`hb_task`) detects that the consumer is gone and attempts to recreate it. However, the current implementation unconditionally sets:

```ruby
ccreq[:deliver_policy] = "by_start_sequence"
ccreq[:opt_start_seq] = watcher._sseq
```

**Issue:** If the KV bucket is empty or no KV updates have been observed yet, `watcher._sseq` remains `0`. JetStream rejects consumer creation with `opt_start_seq=0`, returning `err_code=10094` ("optional start sequence is not set").

This causes the watcher to enter an infinite loop of `ConsumerNotFound -> BadRequest (10094)` errors, never recovering automatically.

## Solution

Check if `watcher._sseq > 0` before forcing the `by_start_sequence` deliver policy:

```ruby
if watcher._sseq.to_i > 0
  ccreq[:deliver_policy] = "by_start_sequence"
  ccreq[:opt_start_seq] = watcher._sseq
else
  ccreq.delete(:opt_start_seq)
end
```

When `_sseq` is 0, the original `deliver_policy` from the initial subscription is preserved (typically `last_per_subject`), allowing the consumer to be recreated successfully.

## Testing

Added a new test case `"should reconnect watches on server restart with empty bucket"` that:
1. Creates an empty KV bucket
2. Starts a watcher (ensuring `_sseq` stays at 0)
3. Simulates server restart
4. Verifies no `BadRequest (10094)` errors occur
5. Confirms the watcher receives new entries after reconnection

## Reproduction

Without this fix, the following scenario fails:

1. Create empty KV bucket
2. Start watcher with `kv.watchall`
3. Kill NATS server
4. Restart NATS server
5. Observe repeated errors in `error_cb`:
   - `ConsumerNotFound`
   - `BadRequest err_code=10094`

## Impact

- **Low risk**: The change only affects the edge case where no KV messages have been received
- **Backward compatible**: Existing behavior for non-empty buckets is preserved
- **No breaking changes**: Only internal consumer recreation logic is modified