### PR TITLE
Fix KV watch perf cliff by never dropping FlowControl control msgs

### DIFF
--- a/lib/nats/io/client.rb
+++ b/lib/nats/io/client.rb
@@ -117,6 +117,10 @@ module NATS
     STATUS_HDR = "Status"
     DESC_HDR = "Description"
     NATS_HDR_LINE_SIZE = NATS_HDR_LINE.bytesize
+    # Prefix of a NATS header with a 100 status line (Idle Heartbeat,
+    # FlowControl Request). These are control-plane signals and must
+    # never be dropped by the slow-consumer check in process_msg.
+    STATUS_MSG_PREFIX_100 = "NATS/1.0 100".freeze
 
     SUB_OP = "SUB"
     EMPTY_MSG = ""
@@ -1038,8 +1042,15 @@ module NATS
         elsif sub.pending_queue
           # Async subscribers use a sized queue for processing
           # and should be able to consume messages in parallel.
-          if (sub.pending_queue.size >= sub.pending_msgs_limit) \
-            || (sub.pending_size >= sub.pending_bytes_limit)
+          #
+          # NATS 100-series status messages (Idle Heartbeat, FlowControl
+          # Request) are control-plane signals from the server and must
+          # never be dropped: a dropped FlowControl ack leaves the push
+          # consumer stalled with no way to recover. Always dispatch them
+          # even when the pending queue is at its limit.
+          is_control = header && header.start_with?(STATUS_MSG_PREFIX_100)
+          if !is_control && ((sub.pending_queue.size >= sub.pending_msgs_limit) \
+            || (sub.pending_size >= sub.pending_bytes_limit))
             err = NATS::IO::SlowConsumer.new("nats: slow consumer, messages dropped")
           else
             hdr = process_hdr(header)

--- a/lib/nats/io/jetstream.rb
+++ b/lib/nats/io/jetstream.rb
@@ -244,7 +244,13 @@ module NATS
         end
         cb = new_cb
       end
-      sub = @nc.subscribe(config.deliver_subject, queue: config.deliver_group, &cb)
+      sub_opts = {queue: config.deliver_group}
+      # Allow callers (e.g. KV watch) to size the subscription's pending
+      # queue so ordered push-consumer catchup can buffer deep bursts
+      # without the read loop dropping messages as "slow consumer".
+      sub_opts[:pending_msgs_limit] = params[:pending_msgs_limit] if params[:pending_msgs_limit]
+      sub_opts[:pending_bytes_limit] = params[:pending_bytes_limit] if params[:pending_bytes_limit]
+      sub = @nc.subscribe(config.deliver_subject, sub_opts, &cb)
       sub.extend(PushSubscription)
       sub.jsi = JS::Sub.new(
         js: self,

--- a/lib/nats/io/kv.rb
+++ b/lib/nats/io/kv.rb
@@ -257,6 +257,13 @@ module NATS
     LAST_STREAM_SEQ_HDR = "Nats-Last-Stream"
     CONSUMER_STALLED_HDR = "Nats-Consumer-Stalled"
 
+    # Pending queue limits applied to the KV watch subscription so the
+    # read loop can buffer large catchup bursts without falling over the
+    # default slow-consumer threshold. Callers can override with
+    # :pending_msgs_limit / :pending_bytes_limit watch params.
+    WATCH_PENDING_MSGS_LIMIT = 1_048_576          # 1M messages
+    WATCH_PENDING_BYTES_LIMIT = 1024 * 1024 * 1024 # 1 GiB
+
     # watch will be signaled when a key that matches the keys
     # pattern is updated.
     # The first update after starting the watch is nil in case
@@ -294,7 +301,18 @@ module NATS
       }
 
       # watch_updates callback.
-      sub = @js.subscribe(subject, config: ordered) do |msg|
+      #
+      # Size the subscription's pending queue generously. During initial
+      # catchup the server can deliver entries much faster than the Ruby
+      # callback can drain them into the watcher's _updates queue; with
+      # the default limit (65,536) a large bucket will hit the slow
+      # consumer threshold and messages would be dropped, including the
+      # FlowControl control messages that keep the ordered push consumer
+      # flowing. A larger limit lets the server's FlowControl be the
+      # throttle rather than our slow-consumer error.
+      sub = @js.subscribe(subject, config: ordered,
+        pending_msgs_limit: params[:pending_msgs_limit] || WATCH_PENDING_MSGS_LIMIT,
+        pending_bytes_limit: params[:pending_bytes_limit] || WATCH_PENDING_BYTES_LIMIT) do |msg|
         synchronize do
           if !init_setup_done
             init_setup.wait(@js.opts[:timeout])


### PR DESCRIPTION
## Summary

Fixes #178. The read loop's slow-consumer guard in `process_msg` dropped messages indiscriminately once a subscription's `pending_queue` hit `DEFAULT_SUB_PENDING_MSGS_LIMIT` (65,536), **including NATS 100-series control messages** (Idle Heartbeat, FlowControl Request). A single dropped FlowControl ack leaves an ordered push consumer stalled with no recovery path, which manifested as a hard cliff in `KeyValue#watchall` past ~50k entries and a permanent hang at 100k.

### Root cause

At high catchup rates the callback thread can't drain the subscription's pending queue as fast as the reader fills it. Once we hit the 65k limit, `process_msg` starts dropping — and because the drop didn't distinguish data messages from control messages, it eventually dropped a FlowControl ack. Without the ack, the server stops sending; without more messages, the queue never drains; the watcher is wedged forever.

### Fix (3 files)

- **`lib/nats/io/client.rb`** — `process_msg` now inspects the raw header for the `NATS/1.0 100` prefix and always dispatches 100-series status messages, bypassing the pending-queue limit. Control-plane signals must never be dropped silently.
- **`lib/nats/io/jetstream.rb`** — `JetStream#subscribe` threads `:pending_msgs_limit` / `:pending_bytes_limit` from params through to `@nc.subscribe` so callers can size the subscription queue for their workload.
- **`lib/nats/io/kv.rb`** — KV watch defaults to `WATCH_PENDING_MSGS_LIMIT = 1_048_576` and `WATCH_PENDING_BYTES_LIMIT = 1 GiB` (user-overridable via watch params). With server FlowControl acks now protected, a larger data-message buffer lets the server's FlowControl be the throttle rather than our slow-consumer check.

The client.rb change alone is sufficient to unstick the watcher; the jetstream.rb + kv.rb changes reduce how often we'd ever hit the slow-consumer guard on realistic KV bucket sizes.

## Benchmark results

Measured on a local nats-server, memory storage, 1 history per key. Before the fix the benchmark hung indefinitely past ~65k entries. After the fix:

| Entries | Wall time | Throughput |
| ---: | ---: | ---: |
| 80,000  | 1.86s  | 43,074/sec |
| 100,000 | 2.29s  | 43,713/sec |
| 200,000 | 4.66s  | 42,945/sec |
| 500,000 | 11.75s | 42,546/sec |

Flat throughput, no cliff, no `SlowConsumer` errors. The benchmark script used is attached to #178.

## Test plan

- [x] `bundle exec rspec spec/kv_spec.rb` — 12 examples, 11 pass. The single failure (`should support get by revision`) reproduces on unmodified `main` and is an unrelated server-version mismatch on `StreamConfig.metadata`.
- [x] Benchmark across 80k / 100k / 200k / 500k entries, no cliff
- [ ] CI matrix across supported nats-server / Ruby versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)