### PR TITLE
Fix TypeError from PullSubscription#fetch called concurrently on the same subscription

### DIFF
--- a/lib/nats/io/jetstream/pull_subscription.rb
+++ b/lib/nats/io/jetstream/pull_subscription.rb
@@ -57,6 +57,16 @@ module NATS
         end
 
         t = MonotonicTime.now
+        # `start_time` is only otherwise assigned in the `batch > 1` branch below, but the final
+        # "did we time out" check after the case statement reads it unconditionally. For batch ==
+        # 1, that leaves `start_time` nil there, normally masked because that branch has its own
+        # earlier timeout check. It surfaces when two threads call #fetch concurrently on the same
+        # subscription: @pending_queue/wait_for_msgs_cond are shared per-subscription, so #dispatch's
+        # `wait_for_msgs_cond.signal` can wake a thread whose own request wasn't the one satisfied.
+        # That thread finds nothing left in the queue, skips its own timeout check, and falls into
+        # the tail check with `start_time == nil`, raising `TypeError: nil can't be coerced into
+        # Float` instead of the intended timeout/empty result.
+        start_time = t
         timeout = params[:timeout] ||= 5
         expires = (timeout * 1_000_000_000) - 100_000
         next_req = {

--- a/spec/js_spec.rb
+++ b/spec/js_spec.rb
@@ -608,6 +608,66 @@ describe "JetStream" do
       expect(cinfo.config.inactive_threshold).to eql(2)
       expect(cinfo.config.mem_storage).to eql(true)
     end
+
+    it "should not raise when multiple threads call fetch(1) concurrently on the same subscription" do
+      nc = NATS.connect(@s.uri)
+      js = nc.jetstream
+      js.add_stream(name: "concurrent-fetch", subjects: ["concurrent-fetch"])
+      sub = js.pull_subscribe("concurrent-fetch", "concurrent-fetch", stream: "concurrent-fetch")
+
+      errors = Queue.new
+      threads = 6.times.map do
+        Thread.new do
+          20.times do
+            sub.fetch(1, timeout: 0.1)
+          rescue NATS::Timeout
+            # Expected, stream is empty.
+          rescue => e
+            errors << e
+          end
+        end
+      end
+      threads.each(&:join)
+
+      expect(errors.size).to eql(0)
+    end
+
+    it "delivers every published message exactly once to concurrent fetch(1) callers" do
+      nc = NATS.connect(@s.uri)
+      js = nc.jetstream
+      js.add_stream(name: "concurrent-delivery", subjects: ["concurrent-delivery"])
+      sub = js.pull_subscribe("concurrent-delivery", "concurrent-delivery", stream: "concurrent-delivery")
+
+      total = 200
+      total.times { |n| js.publish("concurrent-delivery", "msg-#{n}") }
+
+      received = Queue.new
+      errors = Queue.new
+      threads = 6.times.map do
+        Thread.new do
+          loop do
+            msgs = sub.fetch(1, timeout: 0.2)
+            msgs.each do |msg|
+              received << msg.data
+              msg.ack
+            end
+          rescue NATS::Timeout
+            break if received.size >= total
+          rescue => e
+            errors << e
+            break
+          end
+        end
+      end
+      threads.each { |t| t.join(10) }
+
+      all = []
+      all << received.pop until received.empty?
+
+      expect(errors.size).to eql(0)
+      expect(all.size).to eql(total)
+      expect(all.uniq.size).to eql(total)
+    end
   end
 
   describe "Push Subscribe" do


### PR DESCRIPTION
## Problem

`PullSubscription#fetch`'s final timeout check reads `start_time`, but that
local is only ever assigned inside the `batch > 1` branch of the preceding
`case`:

```ruby
when batch > 1
  ...
  start_time = MonotonicTime.now
  ...
end
...
# always reached, regardless of which branch ran:
if msgs.empty? && (MonotonicTime.since(start_time) > timeout)
```

For `batch == 1` (a single `fetch(1)` / `fetch`, the common case), `start_time`
is `nil` when this line runs. That's normally invisible, because the
`batch == 1` branch has its own earlier timeout check using a correctly-scoped
local (`t`), which raises `NATS::Timeout` first — the buggy tail check is never
reached in ordinary, single-threaded use.

It surfaces once two threads call `#fetch` **concurrently on the same
`PullSubscription` object**: `@pending_queue` and `wait_for_msgs_cond` are
shared per-subscription state, and `#dispatch`'s `wait_for_msgs_cond.signal`
wakes exactly one arbitrary waiter — not necessarily the thread whose own
pull request produced that wakeup. When a thread is woken by *another*
thread's signal, it finds `@pending_queue` already drained, so its own
"did I get anything" check inside the `batch == 1` branch stays silent
(no raise), and execution falls through into the tail check with
`start_time == nil`:

```
TypeError: nil can't be coerced into Float
```

...instead of the intended timeout or empty result.

We hit this in production serializing job-queue draining across a thread
pool that fetches from several `PullSubscription`s, some of which are worked
by more than one thread. Reproduced deterministically with N threads looping
`fetch(1)` against a single subscription (a few hundred iterations reliably
reproduces it).

## Fix

Initialize `start_time` alongside `t`, unconditionally, before the branch
that could otherwise skip assigning it. One-line semantic change; nothing
else in the method needed to move.

## Tests

Added two specs under "Pull Subscribe" in `spec/js_spec.rb`:
- Multiple threads calling `fetch(1)` concurrently on the same subscription
  against an empty stream never raises.
- Multiple threads calling `fetch(1)` concurrently on the same subscription
  against a populated stream deliver every message exactly once (no loss, no
  duplication).

Both fail with the exact `TypeError` above against the unpatched code, and
pass with this fix — confirmed locally by reverting just the `pull_subscription.rb`
change and re-running.
